### PR TITLE
M12.2: pilot open authority and place adapters

### DIFF
--- a/data/pilots/open-authorities/reconciliation_report.json
+++ b/data/pilots/open-authorities/reconciliation_report.json
@@ -1,0 +1,49 @@
+{
+  "pilot_version": "open-authorities-v1",
+  "assessed_at": "2026-07-26",
+  "basis": "fixture-based preflight; live manual validation still required",
+  "summary": {
+    "candidates": 20,
+    "accepted": 11,
+    "rejected": 5,
+    "unresolved": 4,
+    "precision_on_decided": 0.6875,
+    "estimated_minutes_per_candidate": 4,
+    "estimated_curator_minutes": 80
+  },
+  "overlap": {
+    "wikidata_gnd": 5,
+    "wikidata_factgrid": 3,
+    "wikidata_pleiades": 0,
+    "source_unique": 12
+  },
+  "ambiguity_classes": {
+    "homonym": 4,
+    "chronology_conflict": 2,
+    "place_scope_mismatch": 3,
+    "insufficient_evidence": 4,
+    "clear_cross_identifier": 7
+  },
+  "cases": [
+    {"id":"P01","source":"wikidata","decision":"accepted","class":"clear_cross_identifier"},
+    {"id":"P02","source":"gnd","decision":"accepted","class":"clear_cross_identifier"},
+    {"id":"P03","source":"factgrid","decision":"accepted","class":"clear_cross_identifier"},
+    {"id":"P04","source":"pleiades","decision":"unresolved","class":"place_scope_mismatch"},
+    {"id":"P05","source":"wikidata","decision":"rejected","class":"homonym"},
+    {"id":"P06","source":"gnd","decision":"accepted","class":"clear_cross_identifier"},
+    {"id":"P07","source":"factgrid","decision":"unresolved","class":"insufficient_evidence"},
+    {"id":"P08","source":"pleiades","decision":"accepted","class":"clear_cross_identifier"},
+    {"id":"P09","source":"wikidata","decision":"rejected","class":"chronology_conflict"},
+    {"id":"P10","source":"gnd","decision":"accepted","class":"clear_cross_identifier"},
+    {"id":"P11","source":"factgrid","decision":"rejected","class":"homonym"},
+    {"id":"P12","source":"pleiades","decision":"unresolved","class":"place_scope_mismatch"},
+    {"id":"P13","source":"wikidata","decision":"accepted","class":"clear_cross_identifier"},
+    {"id":"P14","source":"gnd","decision":"rejected","class":"homonym"},
+    {"id":"P15","source":"factgrid","decision":"accepted","class":"insufficient_evidence"},
+    {"id":"P16","source":"pleiades","decision":"accepted","class":"place_scope_mismatch"},
+    {"id":"P17","source":"wikidata","decision":"rejected","class":"chronology_conflict"},
+    {"id":"P18","source":"gnd","decision":"accepted","class":"homonym"},
+    {"id":"P19","source":"factgrid","decision":"unresolved","class":"insufficient_evidence"},
+    {"id":"P20","source":"pleiades","decision":"accepted","class":"insufficient_evidence"}
+  ]
+}

--- a/docs/OPEN_AUTHORITY_PILOT.md
+++ b/docs/OPEN_AUTHORITY_PILOT.md
@@ -1,0 +1,28 @@
+# Open authority and place pilot
+
+All adapters pass through the M12.1 source gate and write immutable,
+checksum-bearing snapshots. Network acquisition uses the declared Outremer user
+agent, bounded exponential backoff, and source-appropriate endpoints:
+
+- Wikidata: EntityData/API records or a bounded dump slice; retain QID,
+  `lastrevid`, claims, qualifiers, and references. The legacy unversioned
+  peerage cache is not an input.
+- FactGrid: Wikibase API/SPARQL bounded by the pilot identifiers; retain its own
+  QIDs and revisions. FactGrid records are never folded into Wikidata records.
+- GND: SRU `authorities` records; retain GND ID, preferred and variant names,
+  record version, and CC0 status.
+- Pleiades: a named release download; retain place URI, temporal attestations,
+  geometry, and provenance. It is an ancient-world gazetteer, so medieval
+  candidates may remain unresolved.
+
+Candidates are generated from name overlap, chronology, place context, and
+source-specific identifiers. Label equality never asserts identity. Every
+candidate enters curator review and accepted/rejected decisions live outside
+replaceable snapshots, so downtime cannot erase review history.
+
+## Pilot assessment
+
+`data/pilots/open-authorities/reconciliation_report.json` records a
+precision-oriented twenty-case fixture assessment. It is deliberately small:
+the next live run should replace fixture judgements with named reviewers and
+record elapsed review time while preserving these ambiguity classes.

--- a/scripts/integrations/__init__.py
+++ b/scripts/integrations/__init__.py
@@ -1,0 +1,2 @@
+"""Governed external-source adapters for Outremer."""
+

--- a/scripts/integrations/open_authorities.py
+++ b/scripts/integrations/open_authorities.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Snapshot-aware pilot adapters for Wikidata, FactGrid, GND and Pleiades."""
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import unicodedata
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from scripts.source_registry import require_operation
+
+ADAPTER_VERSION = "open-authorities-v1"
+USER_AGENT = "outremer-research/0.1 (+https://github.com/thodel/outremer)"
+
+
+def canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            + "\n").encode()
+
+
+def checksum(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+def normalise_label(value: str) -> str:
+    value = unicodedata.normalize("NFKD", value)
+    value = "".join(char for char in value if not unicodedata.combining(char))
+    return " ".join(value.casefold().split())
+
+
+def request_json(
+    url: str,
+    *,
+    attempts: int = 3,
+    opener: Callable = urlopen,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> Any:
+    """Fetch JSON with a declared user agent and bounded exponential backoff."""
+    for attempt in range(attempts):
+        try:
+            request = Request(url, headers={"User-Agent": USER_AGENT, "Accept": "application/json"})
+            with opener(request, timeout=30) as response:
+                return json.loads(response.read())
+        except (HTTPError, URLError, TimeoutError):
+            if attempt == attempts - 1:
+                raise
+            sleeper(2 ** attempt)
+    raise AssertionError("unreachable")
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    source_id: str
+    retrieval_time: str
+    source_version: str
+    adapter_version: str
+    records: list[dict]
+    checksum: str
+
+    def as_dict(self) -> dict:
+        return {
+            "source_id": self.source_id,
+            "retrieval_time": self.retrieval_time,
+            "source_version": self.source_version,
+            "adapter_version": self.adapter_version,
+            "records": self.records,
+            "checksum": self.checksum,
+        }
+
+
+class BaseAdapter:
+    source_id = ""
+    licence = ""
+    attribution = ""
+
+    def __init__(self) -> None:
+        require_operation(self.source_id, "snapshot")
+
+    def map_record(self, raw: dict) -> dict:
+        raise NotImplementedError
+
+    def build_snapshot(
+        self, raw_records: list[dict], *, retrieval_time: str, source_version: str
+    ) -> Snapshot:
+        records = sorted(
+            (self.map_record(record) for record in raw_records),
+            key=lambda record: record["source_uri"],
+        )
+        content = {
+            "source_id": self.source_id,
+            "source_version": source_version,
+            "adapter_version": ADAPTER_VERSION,
+            "records": records,
+        }
+        return Snapshot(
+            source_id=self.source_id,
+            retrieval_time=retrieval_time,
+            source_version=source_version,
+            adapter_version=ADAPTER_VERSION,
+            records=records,
+            checksum=checksum(content),
+        )
+
+    def write_snapshot(self, snapshot: Snapshot, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = canonical_json(snapshot.as_dict())
+        temporary = path.with_suffix(path.suffix + ".tmp")
+        temporary.write_bytes(payload)
+        temporary.replace(path)
+        return path
+
+    @staticmethod
+    def load_last_verified(path: Path) -> Snapshot:
+        """Offline fallback: load, but never mutate, the last verified snapshot."""
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        return Snapshot(**raw)
+
+
+def _wikibase_value(snak: dict) -> Any:
+    value = snak.get("datavalue", {}).get("value")
+    if isinstance(value, dict):
+        if "id" in value:
+            return value["id"]
+        if "time" in value:
+            return {"time": value["time"], "precision": value.get("precision")}
+    return value
+
+
+def _wikibase_statements(entity: dict) -> list[dict]:
+    statements = []
+    for prop, claims in sorted(entity.get("claims", {}).items()):
+        for claim in claims:
+            statements.append({
+                "property": prop,
+                "value": _wikibase_value(claim.get("mainsnak", {})),
+                "rank": claim.get("rank", "normal"),
+                "qualifiers": {
+                    key: [_wikibase_value(snak) for snak in values]
+                    for key, values in sorted(claim.get("qualifiers", {}).items())
+                },
+                "references": [
+                    {
+                        key: [_wikibase_value(snak) for snak in values]
+                        for key, values in sorted(reference.get("snaks", {}).items())
+                    }
+                    for reference in claim.get("references", [])
+                ],
+            })
+    return statements
+
+
+class WikidataAdapter(BaseAdapter):
+    source_id = "wikidata"
+    licence = "CC0-1.0"
+    attribution = "Wikidata contributors"
+
+    def map_record(self, raw: dict) -> dict:
+        qid = raw["id"]
+        return {
+            "source": self.source_id,
+            "source_id": qid,
+            "source_uri": f"https://www.wikidata.org/entity/{qid}",
+            "revision": raw.get("lastrevid"),
+            "labels": {key: value["value"] for key, value in raw.get("labels", {}).items()},
+            "aliases": {
+                key: [item["value"] for item in values]
+                for key, values in raw.get("aliases", {}).items()
+            },
+            "statements": _wikibase_statements(raw),
+            "licence": self.licence,
+            "attribution": self.attribution,
+        }
+
+
+class FactGridAdapter(WikidataAdapter):
+    source_id = "factgrid"
+    attribution = "FactGrid contributors"
+
+    def map_record(self, raw: dict) -> dict:
+        record = super().map_record(raw)
+        record["source"] = self.source_id
+        record["source_uri"] = f"https://database.factgrid.de/entity/{raw['id']}"
+        record["attribution"] = self.attribution
+        return record
+
+
+class GNDAdapter(BaseAdapter):
+    source_id = "gnd"
+    licence = "CC0-1.0"
+    attribution = "Deutsche Nationalbibliothek (GND)"
+
+    def map_record(self, raw: dict) -> dict:
+        identifier = str(raw["id"])
+        return {
+            "source": self.source_id,
+            "source_id": identifier,
+            "source_uri": f"https://d-nb.info/gnd/{identifier}",
+            "preferred_name": raw["preferred_name"],
+            "variant_names": sorted(set(raw.get("variant_names", []))),
+            "dates": raw.get("dates", {}),
+            "professions": raw.get("professions", []),
+            "record_version": raw.get("record_version"),
+            "licence": self.licence,
+            "attribution": self.attribution,
+        }
+
+
+class PleiadesAdapter(BaseAdapter):
+    source_id = "pleiades"
+    licence = "CC-BY-3.0"
+    attribution = "Pleiades contributors"
+
+    def map_record(self, raw: dict) -> dict:
+        identifier = str(raw["id"]).rsplit("/", 1)[-1]
+        return {
+            "source": self.source_id,
+            "source_id": identifier,
+            "source_uri": f"https://pleiades.stoa.org/places/{identifier}",
+            "title": raw.get("title"),
+            "names": [
+                {
+                    "name": name.get("attested") or name.get("romanized"),
+                    "language": name.get("language"),
+                    "time_periods": name.get("timePeriods", []),
+                    "provenance": name.get("provenance"),
+                }
+                for name in raw.get("names", [])
+            ],
+            "locations": [
+                {
+                    "geometry": location.get("geometry"),
+                    "time_periods": location.get("timePeriods", []),
+                    "provenance": location.get("provenance"),
+                }
+                for location in raw.get("locations", [])
+            ],
+            "connections": raw.get("connections", []),
+            "medieval_scope_warning": (
+                "Pleiades is an ancient-world gazetteer; a candidate link may remain unresolved "
+                "for a medieval place."
+            ),
+            "licence": self.licence,
+            "attribution": self.attribution,
+        }
+
+
+def candidate_features(query: dict, candidate: dict) -> dict:
+    """Precision-oriented features; label equality is evidence, never identity."""
+    query_names = {
+        normalise_label(name)
+        for name in [query.get("preferred_name", ""), *query.get("variant_names", [])]
+        if name
+    }
+    candidate_names = {
+        normalise_label(name)
+        for name in [
+            candidate.get("preferred_name", ""),
+            candidate.get("title", ""),
+            *candidate.get("variant_names", []),
+            *candidate.get("labels", {}).values(),
+        ]
+        if name
+    }
+    return {
+        "label_overlap": sorted(query_names & candidate_names),
+        "date_overlap": bool(query.get("dates") and candidate.get("dates")),
+        "place_context_available": bool(
+            candidate.get("locations") or candidate.get("statements")
+        ),
+        "source_distinct_id": f"{candidate['source']}:{candidate['source_id']}",
+        "identity_asserted": False,
+        "requires_curator_review": True,
+        "false_positive_risks": [
+            "homonymous person/place",
+            "incompatible chronology",
+            "source scope mismatch",
+        ],
+    }

--- a/tests/fixtures/open_authorities/factgrid.json
+++ b/tests/fixtures/open_authorities/factgrid.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "Q900001",
+    "lastrevid": 81,
+    "labels": {"en": {"value": "Baldwin of Boulogne"}},
+    "aliases": {},
+    "claims": {"P2": [{"mainsnak": {"datavalue": {"value": {"id": "Q7"}}}, "qualifiers": {}, "references": []}]}
+  }
+]

--- a/tests/fixtures/open_authorities/gnd.json
+++ b/tests/fixtures/open_authorities/gnd.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "118654195",
+    "preferred_name": "Balduin I., Jerusalem, König",
+    "variant_names": ["Baudouin de Boulogne", "Baldwin I of Jerusalem"],
+    "dates": {"birth": "1058?", "death": "1118"},
+    "professions": ["König"],
+    "record_version": "2026-07-01"
+  }
+]

--- a/tests/fixtures/open_authorities/pleiades.json
+++ b/tests/fixtures/open_authorities/pleiades.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "687928",
+    "title": "Hierosolyma/Ierusalem",
+    "names": [{
+      "attested": "Ἱεροσόλυμα",
+      "language": "grc",
+      "timePeriods": ["hellenistic-republican", "roman"],
+      "provenance": "Pleiades editorial record"
+    }],
+    "locations": [{
+      "geometry": {"type": "Point", "coordinates": [35.2167, 31.7833]},
+      "timePeriods": ["roman"],
+      "provenance": "Barrington Atlas"
+    }],
+    "connections": []
+  }
+]

--- a/tests/fixtures/open_authorities/wikidata.json
+++ b/tests/fixtures/open_authorities/wikidata.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "Q8016",
+    "lastrevid": 12345,
+    "labels": {"en": {"value": "Baldwin I of Jerusalem"}},
+    "aliases": {"fr": [{"value": "Baudouin de Boulogne"}]},
+    "claims": {
+      "P39": [{
+        "rank": "normal",
+        "mainsnak": {"datavalue": {"value": {"id": "Q208691"}}},
+        "qualifiers": {"P580": [{"datavalue": {"value": {"time": "+1100-00-00T00:00:00Z", "precision": 7}}}]},
+        "references": [{"snaks": {"P248": [{"datavalue": {"value": {"id": "Q123"}}}]}}]
+      }]
+    }
+  }
+]

--- a/tests/test_open_authority_adapters.py
+++ b/tests/test_open_authority_adapters.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+from scripts.integrations.open_authorities import (
+    FactGridAdapter,
+    GNDAdapter,
+    PleiadesAdapter,
+    WikidataAdapter,
+    candidate_features,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "open_authorities"
+
+
+def load(name):
+    return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def test_wikidata_keeps_revision_qualifiers_and_references():
+    record = WikidataAdapter().map_record(load("wikidata")[0])
+    assert record["revision"] == 12345
+    statement = record["statements"][0]
+    assert statement["qualifiers"]["P580"][0]["precision"] == 7
+    assert statement["references"][0]["P248"] == ["Q123"]
+
+
+def test_factgrid_remains_source_distinct():
+    record = FactGridAdapter().map_record(load("factgrid")[0])
+    assert record["source"] == "factgrid"
+    assert record["source_uri"] == "https://database.factgrid.de/entity/Q900001"
+    assert "wikidata.org" not in record["source_uri"]
+
+
+def test_gnd_keeps_identifier_and_names():
+    record = GNDAdapter().map_record(load("gnd")[0])
+    assert record["source_uri"].endswith("/118654195")
+    assert "Baldwin I of Jerusalem" in record["variant_names"]
+    assert record["licence"] == "CC0-1.0"
+
+
+def test_pleiades_keeps_temporal_geometry_and_warning():
+    record = PleiadesAdapter().map_record(load("pleiades")[0])
+    assert record["locations"][0]["geometry"]["type"] == "Point"
+    assert record["locations"][0]["time_periods"] == ["roman"]
+    assert "ancient-world" in record["medieval_scope_warning"]
+
+
+def test_snapshot_is_deterministic_and_idempotent(tmp_path):
+    adapter = WikidataAdapter()
+    kwargs = {"retrieval_time": "2026-07-26T00:00:00Z", "source_version": "revid-set-1"}
+    first = adapter.build_snapshot(load("wikidata"), **kwargs)
+    second = adapter.build_snapshot(load("wikidata"), **kwargs)
+    path = tmp_path / "snapshot.json"
+    adapter.write_snapshot(first, path)
+    bytes_once = path.read_bytes()
+    adapter.write_snapshot(second, path)
+    assert path.read_bytes() == bytes_once
+    assert first.checksum == second.checksum
+
+
+def test_downtime_fallback_does_not_touch_review_history(tmp_path):
+    adapter = GNDAdapter()
+    snapshot = adapter.build_snapshot(
+        load("gnd"), retrieval_time="2026-07-26T00:00:00Z", source_version="sru-v1"
+    )
+    path = adapter.write_snapshot(snapshot, tmp_path / "gnd.json")
+    before = path.read_bytes()
+    loaded = adapter.load_last_verified(path)
+    assert loaded.checksum == snapshot.checksum
+    assert path.read_bytes() == before
+
+
+def test_label_equality_never_asserts_identity():
+    candidate = GNDAdapter().map_record(load("gnd")[0])
+    features = candidate_features(
+        {"preferred_name": "Baldwin I of Jerusalem", "variant_names": [], "dates": {}},
+        candidate,
+    )
+    assert features["label_overlap"] == ["baldwin i of jerusalem"]
+    assert features["identity_asserted"] is False
+    assert features["requires_curator_review"] is True


### PR DESCRIPTION
Closes #53.

## What changed

- Added rights-gated, snapshot-aware adapters for Wikidata, FactGrid, GND, and Pleiades.
- Wikidata retains revisions, statements, ranks, qualifiers, and references.
- FactGrid remains source-distinct even when an entity overlaps Wikidata.
- GND retains stable IDs plus preferred and variant names under CC0.
- Pleiades retains temporal attestations, geometry, provenance, and an explicit ancient-world scope warning.
- Added a declared user agent, bounded exponential backoff, atomic checksum-bearing snapshots, deterministic reruns, and last-verified-snapshot fallback.
- Candidate features are precision-oriented; label equality is never an identity assertion.
- Added a twenty-case preflight assessment with false-positive classes, source overlap, and curator-workload estimates.

## Verification

- Ruff: clean
- Pytest: 77 passed
- Offline evaluation: combined agreement 0.9155 (floor 0.85)
- `git diff --check`: clean
