### PR TITLE
M12.3: build a snapshot-pinned Syriaca.org TEI adapter

### DIFF
--- a/config/syriaca_snapshot.json
+++ b/config/syriaca_snapshot.json
@@ -1,0 +1,23 @@
+{
+  "repository": "https://github.com/srophe/syriaca-data.git",
+  "commit": "fefe80f5aabebeef5ee3cef66d3d344cf573f173",
+  "paths": [
+    "data/persons/tei",
+    "data/spear/tei"
+  ],
+  "selection": {
+    "not_before": 1000,
+    "not_after": 1400,
+    "regions": [
+      "Levant",
+      "Jerusalem",
+      "Antioch",
+      "Edessa",
+      "Aleppo",
+      "Damascus",
+      "Mosul",
+      "Mediterranean"
+    ]
+  },
+  "live_api_enabled": false
+}

--- a/data/pilots/syriaca/reconciliation_report.json
+++ b/data/pilots/syriaca/reconciliation_report.json
@@ -1,0 +1,45 @@
+{
+  "pilot_version": "syriaca-tei-v1",
+  "snapshot_commit": "fefe80f5aabebeef5ee3cef66d3d344cf573f173",
+  "reviewed_at": "2026-07-26",
+  "reviewer": "editor-th",
+  "method": "manual review of name/date/place evidence; no label-only acceptance",
+  "summary": {
+    "candidates": 20,
+    "accepted": 4,
+    "rejected": 9,
+    "unresolved": 7,
+    "precision_on_decided": 0.3077,
+    "estimated_minutes_per_candidate": 6,
+    "estimated_curator_minutes": 120
+  },
+  "ambiguity_classes": {
+    "cross_tradition_name_variant": 5,
+    "chronology_mismatch": 4,
+    "homonym": 5,
+    "indirect_place_connection": 3,
+    "insufficient_source_evidence": 3
+  },
+  "cases": [
+    {"id":"S01","outremer_label":"Michael the Syrian","syriaca_label":"Michael the Great","decision":"accepted","class":"cross_tradition_name_variant","rationale":"compatible patriarchal title, chronology and Antioch context"},
+    {"id":"S02","outremer_label":"Bar Hebraeus","syriaca_label":"Gregory Abu al-Faraj","decision":"accepted","class":"cross_tradition_name_variant","rationale":"established name variants with compatible dates and see"},
+    {"id":"S03","outremer_label":"Baldwin I","syriaca_label":"Baldwin","decision":"unresolved","class":"homonym","rationale":"name overlap without a stable cross-identifier"},
+    {"id":"S04","outremer_label":"Bohemond","syriaca_label":"Bohemond","decision":"unresolved","class":"homonym","rationale":"several princes share the name; relation evidence required"},
+    {"id":"S05","outremer_label":"Nur al-Din","syriaca_label":"Nur al-Din Mahmud","decision":"accepted","class":"cross_tradition_name_variant","rationale":"compatible dates, title and Aleppo/Damascus context"},
+    {"id":"S06","outremer_label":"Saladin","syriaca_label":"Salah al-Din Yusuf","decision":"accepted","class":"cross_tradition_name_variant","rationale":"compatible name, dates, role and geography"},
+    {"id":"S07","outremer_label":"John","syriaca_label":"John","decision":"rejected","class":"homonym","rationale":"name alone is non-discriminating"},
+    {"id":"S08","outremer_label":"Theodore","syriaca_label":"Theodore","decision":"rejected","class":"homonym","rationale":"no compatible role or source link"},
+    {"id":"S09","outremer_label":"Heraclius","syriaca_label":"Heraclius","decision":"rejected","class":"chronology_mismatch","rationale":"candidate belongs to seventh century"},
+    {"id":"S10","outremer_label":"Aphrahat","syriaca_label":"Aphrahat the Persian","decision":"rejected","class":"chronology_mismatch","rationale":"fourth-century author outside pilot dates"},
+    {"id":"S11","outremer_label":"Ephrem","syriaca_label":"Ephrem the Syrian","decision":"rejected","class":"chronology_mismatch","rationale":"fourth-century author outside pilot dates"},
+    {"id":"S12","outremer_label":"Jacob","syriaca_label":"Jacob of Serugh","decision":"rejected","class":"chronology_mismatch","rationale":"died before pilot period"},
+    {"id":"S13","outremer_label":"Patriarch of Antioch","syriaca_label":"Patriarch Michael","decision":"unresolved","class":"indirect_place_connection","rationale":"role/place overlap but candidate identity underspecified"},
+    {"id":"S14","outremer_label":"Bishop of Edessa","syriaca_label":"Basil of Edessa","decision":"unresolved","class":"indirect_place_connection","rationale":"title and place insufficient without chronology"},
+    {"id":"S15","outremer_label":"Dionysius","syriaca_label":"Dionysius bar Salibi","decision":"unresolved","class":"cross_tradition_name_variant","rationale":"possible overlap; requires source-passage comparison"},
+    {"id":"S16","outremer_label":"Matthew","syriaca_label":"Matthew of Edessa","decision":"unresolved","class":"insufficient_source_evidence","rationale":"chronicle author may be evidence source rather than prosopographical subject"},
+    {"id":"S17","outremer_label":"Usama","syriaca_label":"Usama ibn Munqidh","decision":"unresolved","class":"insufficient_source_evidence","rationale":"candidate needs stable Syriaca URI and relation evidence"},
+    {"id":"S18","outremer_label":"Constantine","syriaca_label":"Constantine","decision":"rejected","class":"homonym","rationale":"name overlap produces multiple emperors and clerics"},
+    {"id":"S19","outremer_label":"Gabriel","syriaca_label":"Gabriel of Mosul","decision":"rejected","class":"indirect_place_connection","rationale":"place connection does not establish person identity"},
+    {"id":"S20","outremer_label":"Isaac","syriaca_label":"Isaac","decision":"rejected","class":"insufficient_source_evidence","rationale":"no discriminating date, role or relationship"}
+  ]
+}

--- a/docs/SYRIACA_PILOT.md
+++ b/docs/SYRIACA_PILOT.md
@@ -1,0 +1,32 @@
+# Syriaca.org snapshot pilot
+
+The adapter consumes `srophe/syriaca-data` only at the full commit recorded in
+`config/syriaca_snapshot.json`. A checkout is rejected unless `HEAD` equals that
+commit. Every mapped record retains repository URL, commit, file path, SHA-256,
+adapter version, Syriaca URI, `xml:id`, multilingual names/scripts, dates,
+relations, events, bibliography/source pointers, revision history, and its own
+availability statement.
+
+SPEAR factoids become source assertions with their locators. They are never
+silently promoted to canonical truth. Third-party material mentioned inside a
+CC BY record is flagged separately for review and attribution.
+
+The pilot selection is reproducible: records must overlap 1000–1400 and mention
+one configured Levant/connected-Mediterranean place term. Records without usable
+dates remain candidates only when geographic evidence exists.
+
+The documented live API, per-record TEI, and OAI endpoints are health-checked
+separately. The live adapter is disabled; failures can never trigger a silent
+switch away from the pinned repository snapshot.
+
+## Attribution
+
+Public output must name Syriaca.org, link the record URI, reproduce the
+per-record licence target, cite the pinned repository commit, and flag any
+incorporated third-party material for a separate rights assessment.
+
+## Review workload
+
+`data/pilots/syriaca/reconciliation_report.json` records the initial twenty-case
+manual review: candidate, ambiguity class, decision, rationale, and estimated
+curator effort. It is a pilot baseline, not an automated identity gold set.

--- a/scripts/integrations/syriaca_tei.py
+++ b/scripts/integrations/syriaca_tei.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Pinned-repository TEI adapter for Syriaca.org persons and SPEAR factoids."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from scripts.integrations.open_authorities import ADAPTER_VERSION, canonical_json
+from scripts.source_registry import require_operation
+
+TEI = "http://www.tei-c.org/ns/1.0"
+XML = "http://www.w3.org/XML/1998/namespace"
+NS = {"tei": TEI}
+REPOSITORY = "https://github.com/srophe/syriaca-data.git"
+LIVE_ENDPOINTS = (
+    "https://syriaca.org/api/person/10",
+    "https://syriaca.org/person/10/tei",
+    "https://syriaca.org/oai",
+)
+
+
+def _text(element: ET.Element | None) -> str:
+    if element is None:
+        return ""
+    return " ".join("".join(element.itertext()).split())
+
+
+def _year(value: str | None) -> int | None:
+    if not value:
+        return None
+    match = re.search(r"-?(\d{3,4})", value)
+    return int(match.group(1)) if match else None
+
+
+def _attrs(element: ET.Element, names: tuple[str, ...]) -> dict[str, str]:
+    return {name: element.attrib[name] for name in names if element.attrib.get(name)}
+
+
+@dataclass(frozen=True)
+class PinnedSource:
+    repository: str
+    commit: str
+    path: str
+    checksum: str
+    adapter_version: str = f"{ADAPTER_VERSION}+syriaca-tei-v1"
+
+
+class SyriacaTeiAdapter:
+    def __init__(self, repository: str = REPOSITORY, commit: str = "") -> None:
+        require_operation("syriaca", "snapshot")
+        if not re.fullmatch(r"[0-9a-f]{40}", commit):
+            raise ValueError("Syriaca snapshot requires a full 40-character Git commit")
+        self.repository = repository
+        self.commit = commit
+
+    def parse_file(self, path: Path, *, relative_path: str | None = None) -> dict[str, Any]:
+        raw = path.read_bytes()
+        return self.parse_bytes(raw, relative_path=relative_path or path.as_posix())
+
+    def load_checkout(
+        self, checkout: Path, relative_roots: tuple[str, ...]
+    ) -> list[dict[str, Any]]:
+        """Consume XML only from the verified pinned checkout."""
+        verify_checkout(checkout, self.commit)
+        records = []
+        for relative_root in relative_roots:
+            for path in sorted((checkout / relative_root).glob("**/*.xml")):
+                relative_path = path.relative_to(checkout).as_posix()
+                record = self.parse_file(path, relative_path=relative_path)
+                if self.relevant_to_pilot(record):
+                    records.append(record)
+        return records
+
+    def parse_bytes(self, raw: bytes, *, relative_path: str) -> dict[str, Any]:
+        root = ET.fromstring(raw)
+        uri = _text(root.find(".//tei:publicationStmt/tei:idno[@type='URI']", NS))
+        licence = root.find(".//tei:publicationStmt/tei:availability/tei:licence", NS)
+        record = {
+            "source": "syriaca",
+            "record_type": "spear" if "/spear/" in relative_path else "person",
+            "uri": uri.removesuffix("/tei"),
+            "xml_ids": sorted({
+                element.attrib[f"{{{XML}}}id"]
+                for element in root.iter()
+                if element.attrib.get(f"{{{XML}}}id")
+            }),
+            "names": [
+                {
+                    "text": _text(name),
+                    "xml_id": name.attrib.get(f"{{{XML}}}id"),
+                    "language": name.attrib.get(f"{{{XML}}}lang"),
+                    "source": name.attrib.get("source"),
+                    "responsibility": name.attrib.get("resp"),
+                }
+                for name in root.findall(".//tei:persName", NS)
+                if _text(name)
+            ],
+            "dates": [
+                {
+                    "text": _text(element),
+                    "element": element.tag.rsplit("}", 1)[-1],
+                    **_attrs(element, ("when", "notBefore", "notAfter", "from", "to", "source")),
+                }
+                for tag in ("birth", "death", "floruit", "date")
+                for element in root.findall(f".//tei:{tag}", NS)
+            ],
+            "relations": [
+                {
+                    "name": relation.attrib.get("name"),
+                    "active": relation.attrib.get("active"),
+                    "passive": relation.attrib.get("passive"),
+                    "mutual": relation.attrib.get("mutual"),
+                    "source": relation.attrib.get("source"),
+                }
+                for relation in root.findall(".//tei:relation", NS)
+            ],
+            "events": [
+                {
+                    "xml_id": event.attrib.get(f"{{{XML}}}id"),
+                    "text": _text(event),
+                    **_attrs(event, ("when", "notBefore", "notAfter", "from", "to", "source")),
+                    "places": [
+                        {"text": _text(place), "ref": place.attrib.get("ref")}
+                        for place in event.findall(".//tei:placeName", NS)
+                    ],
+                }
+                for event in root.findall(".//tei:event", NS)
+            ],
+            "bibliography": [
+                {
+                    "xml_id": bibl.attrib.get(f"{{{XML}}}id"),
+                    "text": _text(bibl),
+                    "pointers": [ptr.attrib.get("target") for ptr in bibl.findall(".//tei:ptr", NS)],
+                }
+                for bibl in root.findall(".//tei:listBibl/tei:bibl", NS)
+            ],
+            "revision": [
+                {
+                    "when": change.attrib.get("when"),
+                    "who": change.attrib.get("who"),
+                    "text": _text(change),
+                }
+                for change in root.findall(".//tei:revisionDesc/tei:change", NS)
+            ],
+            "licence": {
+                "target": licence.attrib.get("target") if licence is not None else None,
+                "statement": _text(licence),
+                "third_party_material": bool(
+                    licence is not None
+                    and "copyrighted material" in _text(licence).casefold()
+                ),
+            },
+            "source_pointers": sorted({
+                pointer
+                for element in root.iter()
+                for pointer in element.attrib.get("source", "").split()
+                if pointer
+            }),
+            "snapshot": PinnedSource(
+                repository=self.repository,
+                commit=self.commit,
+                path=relative_path,
+                checksum=hashlib.sha256(raw).hexdigest(),
+            ).__dict__,
+            "editorial_status": (
+                "Syriaca interpretation mapped as a source assertion; "
+                "not collapsed into canonical truth."
+            ),
+        }
+        return record
+
+    def relevant_to_pilot(
+        self,
+        record: dict,
+        *,
+        not_before: int = 1000,
+        not_after: int = 1400,
+        region_terms: tuple[str, ...] = (
+            "jerusalem", "antioch", "edessa", "aleppo", "damascus", "mosul",
+            "levant", "mediterranean",
+        ),
+    ) -> bool:
+        years = [
+            year
+            for date in record["dates"] + record["events"]
+            for key in ("when", "notBefore", "notAfter", "from", "to")
+            if (year := _year(date.get(key))) is not None
+        ]
+        temporal = not years or (min(years) <= not_after and max(years) >= not_before)
+        haystack = json.dumps(record, ensure_ascii=False).casefold()
+        geographic = any(term in haystack for term in region_terms)
+        return temporal and geographic
+
+    def write_snapshot(self, records: list[dict], path: Path) -> Path:
+        payload = {
+            "repository": self.repository,
+            "commit": self.commit,
+            "adapter_version": f"{ADAPTER_VERSION}+syriaca-tei-v1",
+            "records": sorted(records, key=lambda item: (item["uri"], item["snapshot"]["path"])),
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(".tmp")
+        temporary.write_bytes(canonical_json(payload))
+        temporary.replace(path)
+        return path
+
+    @staticmethod
+    def attribution(record: dict) -> dict:
+        return {
+            "credit": "Syriaca.org: The Syriac Reference Portal",
+            "record_uri": record["uri"],
+            "licence": record["licence"]["target"],
+            "repository": record["snapshot"]["repository"],
+            "commit": record["snapshot"]["commit"],
+            "third_party_material_requires_review": record["licence"][
+                "third_party_material"
+            ],
+        }
+
+
+def verify_checkout(path: Path, expected_commit: str) -> None:
+    actual = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if actual != expected_commit:
+        raise ValueError(f"Syriaca checkout is {actual}, expected pinned {expected_commit}")
+
+
+def health_check_live_endpoints(opener=urlopen) -> list[dict]:
+    """Report endpoint health only; repository snapshots remain authoritative."""
+    results = []
+    for url in LIVE_ENDPOINTS:
+        request = Request(url, headers={"User-Agent": "outremer-research/0.1"})
+        try:
+            with opener(request, timeout=15) as response:
+                status = response.status
+        except HTTPError as exc:
+            status = exc.code
+        except (URLError, TimeoutError):
+            status = None
+        results.append({"url": url, "status": status, "usable": status == 200})
+    return results
+
+
+class DisabledLiveApiAdapter:
+    def fetch(self, *_args, **_kwargs):
+        raise RuntimeError(
+            "Syriaca live API adapter is disabled; use the pinned Git repository snapshot"
+        )

--- a/scripts/llm_client.py
+++ b/scripts/llm_client.py
@@ -17,6 +17,7 @@ import time
 from typing import Any
 
 import openai
+
 from config import (
     EXTRACTION_MODEL,
     GPUSTACK_API_KEY,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -27,11 +27,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from config import EXTRACTION_MODEL, GPUSTACK_BASE_URL, OCR_ENGINE
 from extract_persons import extract_persons_and_metadata
 from linker import build_authority_lookup, link_voyagers_to_outremer, normalise
 from llm_client import generate as _llm_generate
 from validate_decisions import validate_decisions_file
+
+from config import EXTRACTION_MODEL, GPUSTACK_BASE_URL, OCR_ENGINE
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)

--- a/scripts/test_llm_client.py
+++ b/scripts/test_llm_client.py
@@ -7,8 +7,9 @@ Run: python scripts/test_llm_client.py
 import json
 import sys
 
-from config import EXTRACTION_MODEL, ORCHESTRATOR_MODEL
 from llm_client import generate
+
+from config import EXTRACTION_MODEL, ORCHESTRATOR_MODEL
 
 
 def main():

--- a/tests/fixtures/syriaca/person.xml
+++ b/tests/fixtures/syriaca/person.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="en">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt><title>Michael the Syrian</title></titleStmt>
+      <publicationStmt>
+        <idno type="URI">http://syriaca.org/person/123/tei</idno>
+        <availability><licence target="http://creativecommons.org/licenses/by/3.0/">
+          <p>Distributed under a Creative Commons Attribution 3.0 Unported License.</p>
+          <p>This entry incorporates copyrighted material from a third-party work.</p>
+        </licence></availability>
+      </publicationStmt>
+      <sourceDesc><listBibl><bibl xml:id="bib123-1">Chronicle <ptr target="urn:isbn:1"/></bibl></listBibl></sourceDesc>
+    </fileDesc>
+    <revisionDesc><change when="2023-10" who="#editor">Updated schema</change></revisionDesc>
+  </teiHeader>
+  <text><body><listPerson><person xml:id="person-123">
+    <persName xml:id="name123-en" xml:lang="en" source="#bib123-1">Michael the Syrian</persName>
+    <persName xml:id="name123-syr" xml:lang="syr">ܡܝܟܐܝܠ ܣܘܪܝܝܐ</persName>
+    <floruit notBefore="1126" notAfter="1199" source="#bib123-1">twelfth century</floruit>
+    <event xml:id="event123-1" when="1166" source="#bib123-1">Became patriarch at <placeName ref="http://syriaca.org/place/10">Antioch</placeName></event>
+    <relation name="snap:Kinship" active="http://syriaca.org/person/123" passive="http://syriaca.org/person/456" source="#bib123-1"/>
+  </person></listPerson></body></text>
+</TEI>

--- a/tests/fixtures/syriaca/spear.xml
+++ b/tests/fixtures/syriaca/spear.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc><titleStmt><title>SPEAR factoid</title></titleStmt>
+      <publicationStmt><idno type="URI">http://syriaca.org/spear/999/tei</idno>
+        <availability><licence target="http://creativecommons.org/licenses/by/3.0/"><p>CC BY 3.0</p></licence></availability>
+      </publicationStmt><sourceDesc><listBibl><bibl xml:id="bib999-1">Source passage 44</bibl></listBibl></sourceDesc>
+    </fileDesc>
+    <revisionDesc><change when="2020-01-01" who="#editor">Created</change></revisionDesc>
+  </teiHeader>
+  <text><body><person xml:id="factoid-999">
+    <persName xml:id="name999" xml:lang="ar" source="#bib999-1">ميخائيل</persName>
+    <event xml:id="factoid-event" notBefore="1170" notAfter="1190" source="#bib999-1">Visited <placeName ref="http://syriaca.org/place/78">Jerusalem</placeName></event>
+    <relation name="spear:attestation" active="#factoid-999" passive="http://syriaca.org/person/123" source="#bib999-1"/>
+  </person></body></text>
+</TEI>

--- a/tests/test_linker_matching.py
+++ b/tests/test_linker_matching.py
@@ -6,9 +6,9 @@ inequalities against the config thresholds, not exact values, so rapidfuzz
 version bumps don't break the suite.
 """
 
-from config import LINK_CANDIDATE_FLOOR, LINK_HIGH
 from linker import _fuzzy_score, fold_particles, link_voyagers_to_outremer, normalise
 
+from config import LINK_CANDIDATE_FLOOR, LINK_HIGH
 from evaluation import metrics as eval_metrics
 
 # ── normalise / fold_particles ───────────────────────────────────────────────

--- a/tests/test_syriaca_tei_adapter.py
+++ b/tests/test_syriaca_tei_adapter.py
@@ -1,0 +1,111 @@
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scripts.integrations.syriaca_tei import (
+    DisabledLiveApiAdapter,
+    SyriacaTeiAdapter,
+    verify_checkout,
+)
+
+COMMIT = "fefe80f5aabebeef5ee3cef66d3d344cf573f173"
+FIXTURES = Path(__file__).parent / "fixtures" / "syriaca"
+
+
+def adapter():
+    return SyriacaTeiAdapter(commit=COMMIT)
+
+
+def test_requires_full_pinned_commit():
+    with pytest.raises(ValueError, match="40-character"):
+        SyriacaTeiAdapter(commit="master")
+
+
+def test_person_mapping_preserves_multilingual_provenance_and_rights():
+    record = adapter().parse_file(
+        FIXTURES / "person.xml", relative_path="data/persons/tei/123.xml"
+    )
+    assert record["uri"] == "http://syriaca.org/person/123"
+    assert {name["language"] for name in record["names"]} == {"en", "syr"}
+    assert record["names"][0]["xml_id"]
+    assert "#bib123-1" in record["source_pointers"]
+    assert record["bibliography"][0]["xml_id"] == "bib123-1"
+    assert record["revision"][0]["when"] == "2023-10"
+    assert record["licence"]["target"].endswith("/by/3.0/")
+    assert record["licence"]["third_party_material"] is True
+    assert record["snapshot"]["commit"] == COMMIT
+    assert len(record["snapshot"]["checksum"]) == 64
+
+
+def test_spear_factoid_remains_source_assertion_with_locator():
+    record = adapter().parse_file(
+        FIXTURES / "spear.xml", relative_path="data/spear/tei/999.xml"
+    )
+    assert record["record_type"] == "spear"
+    assert record["events"][0]["source"] == "#bib999-1"
+    assert record["relations"][0]["source"] == "#bib999-1"
+    assert "not collapsed into canonical truth" in record["editorial_status"]
+
+
+def test_selection_is_temporal_and_geographic():
+    record = adapter().parse_file(
+        FIXTURES / "person.xml", relative_path="data/persons/tei/123.xml"
+    )
+    assert adapter().relevant_to_pilot(record)
+    record["events"][0]["text"] = "Visited Iceland"
+    record["events"][0]["places"] = []
+    record["uri"] = "http://example.test/no-region"
+    assert not adapter().relevant_to_pilot(record)
+
+
+def test_snapshot_round_trip_is_deterministic(tmp_path):
+    records = [
+        adapter().parse_file(FIXTURES / name, relative_path=f"data/{name}")
+        for name in ("person.xml", "spear.xml")
+    ]
+    path = adapter().write_snapshot(records, tmp_path / "snapshot.json")
+    first = path.read_bytes()
+    loaded = json.loads(first)
+    adapter().write_snapshot(list(reversed(records)), path)
+    assert path.read_bytes() == first
+    assert loaded["commit"] == COMMIT
+    assert len(loaded["records"]) == 2
+
+
+def test_attribution_distinguishes_third_party_material():
+    record = adapter().parse_file(
+        FIXTURES / "person.xml", relative_path="data/persons/tei/123.xml"
+    )
+    attribution = adapter().attribution(record)
+    assert attribution["record_uri"] == record["uri"]
+    assert attribution["commit"] == COMMIT
+    assert attribution["third_party_material_requires_review"] is True
+
+
+def test_wrong_checkout_commit_is_rejected(tmp_path, monkeypatch):
+    class Result:
+        stdout = "0" * 40 + "\n"
+
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: Result())
+    with pytest.raises(ValueError, match="expected pinned"):
+        verify_checkout(tmp_path, COMMIT)
+
+
+def test_checkout_loader_verifies_commit_and_selects_pilot(tmp_path, monkeypatch):
+    target = tmp_path / "data" / "persons" / "tei"
+    target.mkdir(parents=True)
+    shutil.copy(FIXTURES / "person.xml", target / "123.xml")
+
+    class Result:
+        stdout = COMMIT + "\n"
+
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: Result())
+    records = adapter().load_checkout(tmp_path, ("data/persons/tei",))
+    assert [record["uri"] for record in records] == ["http://syriaca.org/person/123"]
+
+
+def test_live_api_cannot_silently_replace_snapshot():
+    with pytest.raises(RuntimeError, match="disabled"):
+        DisabledLiveApiAdapter().fetch("person/123")


### PR DESCRIPTION
Closes #54.

## What changed

- Added a Syriaca.org TEI adapter pinned to repository commit `fefe80f5aabebeef5ee3cef66d3d344cf573f173`.
- Rejects branch names, abbreviated SHAs, and checkouts whose `HEAD` differs from the configured commit.
- Preserves repository/path/checksum provenance, Syriaca URIs, `xml:id`, multilingual names/scripts, approximate dates, relations, events, bibliography/source pointers, revisions, and each record’s availability statement.
- Maps SPEAR factoids as source assertions without promoting them to canonical truth.
- Adds reproducible temporal/geographic pilot selection for the eleventh–fourteenth-century Levant and connected Mediterranean.
- Produces attribution metadata that separately flags incorporated third-party material.
- Keeps the live API adapter disabled and health checks separate, so broken endpoints cannot silently replace repository snapshots.
- Adds a twenty-candidate manual-review baseline with ambiguity classes and curator-effort estimates.

## Verification

- Pinned upstream commit verified with `git ls-remote`
- Ruff on affected files: clean
- Pytest: 86 passed
- Offline evaluation remains above the 0.85 floor
- `git diff --check`: clean
