### PR TITLE
M11.1: separate evidence, assertions, and identity hypotheses

### DIFF
--- a/docs/EVIDENCE_FIRST_MODEL.md
+++ b/docs/EVIDENCE_FIRST_MODEL.md
@@ -1,0 +1,33 @@
+# Evidence-first canonical contract v1
+
+The operational schema is `schema/evidence-first-v1.schema.json`, version
+`1.0.0`. Its central rule is simple: adapters create evidence objects and
+identity hypotheses; they never silently merge people.
+
+The chain is:
+
+`source_work → manifestation → snapshot → passage → mention/assertion`
+
+Persons and groups are editorial identity nodes. An `identity_hypothesis`
+connects a verbatim mention to ranked candidates. Decisions are immutable,
+attributed review events. Rejection, dispute, and supersession add new objects;
+they never delete the mention, assertion, candidate, or earlier decision.
+
+Local IDs use `outremer:<type>:<stable-token>`. Generated IDs hash the object
+type and stable source coordinates. Source-native identifiers remain in
+`source_native_ids`; they are not used as proof that two identity nodes are the
+same. Objects carry integer versions, optional `supersedes`, and optional
+`tombstone` markers.
+
+Every assertion has one or more passages. Every passage belongs to an immutable
+checksum-bearing snapshot. Every mention preserves the exact text plus language
+and script where known.
+
+Run the read-only migration inventory with:
+
+```bash
+python3 scripts/migrate_evidence_model.py --output /tmp/migration-report.json
+```
+
+It inventories current authority, Wikidata, extraction, and quarantined DHI/FMG
+structures and verifies that `data/decisions.json` is byte-for-byte unchanged.

--- a/fixtures/evidence-first/representative.json
+++ b/fixtures/evidence-first/representative.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0.0",
+  "objects": [
+    {"id":"outremer:source_work:munro","type":"source_work","version":1,"title":"The Popes and the Crusades"},
+    {"id":"outremer:manifestation:munro-pdf","type":"manifestation","version":1,"work_id":"outremer:source_work:munro","citation":"Munro 1916 PDF"},
+    {"id":"outremer:snapshot:munro-sha","type":"snapshot","version":1,"manifestation_id":"outremer:manifestation:munro-pdf","checksum":"1111111111111111111111111111111111111111111111111111111111111111","retrieved_at":"2026-07-26T00:00:00Z","source_locator":"data/raw/Munro-PopesCrusades-1916.pdf"},
+    {"id":"outremer:passage:munro-p12","type":"passage","version":1,"snapshot_id":"outremer:snapshot:munro-sha","locator":"PDF p. 12, lines 4–7","text":"Baldwin perhaps joined the expedition."},
+    {"id":"outremer:mention:baldwin","type":"mention","version":1,"passage_id":"outremer:passage:munro-p12","verbatim":"Baldwin","language":"en","script":"Latn","mention_kind":"person"},
+    {"id":"outremer:mention:anonymous","type":"mention","version":1,"passage_id":"outremer:passage:munro-p12","verbatim":"the pilgrims","language":"en","script":"Latn","mention_kind":"group"},
+    {"id":"outremer:person:baldwin-i","type":"person","version":1,"preferred_label":"Baldwin I of Jerusalem","source_native_ids":{"wikidata":"Q8016"}},
+    {"id":"outremer:person:baldwin-ii","type":"person","version":1,"preferred_label":"Baldwin II of Jerusalem","source_native_ids":{"wikidata":"Q314164"}},
+    {"id":"outremer:group:pilgrims","type":"group","version":1,"preferred_label":"Anonymous pilgrims"},
+    {"id":"outremer:assertion:participation-1","type":"assertion","version":1,"passage_ids":["outremer:passage:munro-p12"],"subject_id":"outremer:person:baldwin-i","predicate":"possibly_participated_in","object":"expedition","participants":[{"role":"participant","identity_id":"outremer:person:baldwin-i"}]},
+    {"id":"outremer:assertion:contradiction","type":"assertion","version":1,"passage_ids":["outremer:passage:munro-p12"],"subject_id":"outremer:person:baldwin-i","predicate":"did_not_participate_in","object":"expedition","participants":[]},
+    {"id":"outremer:identity_hypothesis:baldwin","type":"identity_hypothesis","version":1,"mention_id":"outremer:mention:baldwin","candidates":[{"identity_id":"outremer:person:baldwin-i","score":0.72,"features":{"name":true}},{"identity_id":"outremer:person:baldwin-ii","score":0.69,"features":{"name":true}}]},
+    {"id":"outremer:activity:review-1","type":"activity","version":1,"activity_kind":"review","agent":"reviewer-alpha","started_at":"2026-07-26T00:00:00Z","adapter_version":null},
+    {"id":"outremer:decision:reject-bii","type":"decision","version":1,"hypothesis_id":"outremer:identity_hypothesis:baldwin","candidate_id":"outremer:person:baldwin-ii","status":"rejected","activity_id":"outremer:activity:review-1","comment":"Chronology conflicts."},
+    {"id":"outremer:activity:review-2","type":"activity","version":1,"activity_kind":"review","agent":"reviewer-beta","started_at":"2026-07-26T01:00:00Z","adapter_version":null},
+    {"id":"outremer:decision:accept-bi","type":"decision","version":1,"hypothesis_id":"outremer:identity_hypothesis:baldwin","candidate_id":"outremer:person:baldwin-i","status":"accepted","activity_id":"outremer:activity:review-2","comment":"Source and chronology align."},
+    {"id":"outremer:decision:superseded-bi","type":"decision","version":2,"supersedes":"outremer:decision:accept-bi","hypothesis_id":"outremer:identity_hypothesis:baldwin","candidate_id":"outremer:person:baldwin-i","status":"superseded","activity_id":"outremer:activity:review-2","comment":"Preserved while a contradiction is investigated."}
+  ]
+}

--- a/schema/evidence-first-v1.schema.json
+++ b/schema/evidence-first-v1.schema.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outremer.example/schema/evidence-first-v1.schema.json",
+  "title": "Outremer evidence-first canonical dataset",
+  "type": "object",
+  "required": ["schema_version", "objects"],
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "objects": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/object"}
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "id": {"type": "string", "pattern": "^outremer:[a-z_]+:[a-zA-Z0-9._~-]+$"},
+    "base": {
+      "type": "object",
+      "required": ["id", "type", "version"],
+      "properties": {
+        "id": {"$ref": "#/$defs/id"},
+        "type": {"type": "string"},
+        "version": {"type": "integer", "minimum": 1},
+        "supersedes": {"$ref": "#/$defs/id"},
+        "tombstone": {"type": "boolean", "default": false},
+        "source_native_ids": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        }
+      }
+    },
+    "object": {
+      "oneOf": [
+        {"$ref": "#/$defs/source_work"},
+        {"$ref": "#/$defs/manifestation"},
+        {"$ref": "#/$defs/snapshot"},
+        {"$ref": "#/$defs/passage"},
+        {"$ref": "#/$defs/mention"},
+        {"$ref": "#/$defs/assertion"},
+        {"$ref": "#/$defs/identity"},
+        {"$ref": "#/$defs/hypothesis"},
+        {"$ref": "#/$defs/decision"},
+        {"$ref": "#/$defs/activity"}
+      ]
+    },
+    "source_work": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {"type": {"const": "source_work"}, "title": {"type": "string"}},
+          "required": ["title"]
+        }
+      ]
+    },
+    "manifestation": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {
+            "type": {"const": "manifestation"},
+            "work_id": {"$ref": "#/$defs/id"},
+            "citation": {"type": "string"}
+          },
+          "required": ["work_id", "citation"]
+        }
+      ]
+    },
+    "snapshot": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {
+            "type": {"const": "snapshot"},
+            "manifestation_id": {"$ref": "#/$defs/id"},
+            "checksum": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+            "retrieved_at": {"type": "string", "format": "date-time"},
+            "source_locator": {"type": "string"}
+          },
+          "required": ["manifestation_id", "checksum", "retrieved_at", "source_locator"]
+        }
+      ]
+    },
+    "passage": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {
+            "type": {"const": "passage"},
+            "snapshot_id": {"$ref": "#/$defs/id"},
+            "locator": {"type": "string"},
+            "text": {"type": "string"}
+          },
+          "required": ["snapshot_id", "locator", "text"]
+        }
+      ]
+    },
+    "mention": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {
+            "type": {"const": "mention"},
+            "passage_id": {"$ref": "#/$defs/id"},
+            "verbatim": {"type": "string", "minLength": 1},
+            "language": {"type": ["string", "null"]},
+            "script": {"type": ["string", "null"]},
+            "mention_kind": {"enum": ["person", "group", "anonymous", "place", "other"]}
+          },
+          "required": ["passage_id", "verbatim", "mention_kind"]
+        }
+      ]
+    },
+    "assertion": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {
+            "type": {"const": "assertion"},
+            "passage_ids": {
+              "type": "array", "minItems": 1, "uniqueItems": true,
+              "items": {"$ref": "#/$defs/id"}
+            },
+            "subject_id": {"$ref": "#/$defs/id"},
+            "predicate": {"type": "string"},
+            "object": {},
+            "participants": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["role", "identity_id"],
+                "properties": {
+                  "role": {"type": "string"},
+                  "identity_id": {"$ref": "#/$defs/id"}
+                }
+              }
+            }
+          },
+          "required": ["passage_ids", "subject_id", "predicate", "object"]
+        }
+      ]
+    },
+    "identity": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {
+            "type": {"enum": ["person", "group"]},
+            "preferred_label": {"type": "string"}
+          },
+          "required": ["preferred_label"]
+        }
+      ]
+    },
+    "hypothesis": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {
+            "type": {"const": "identity_hypothesis"},
+            "mention_id": {"$ref": "#/$defs/id"},
+            "candidates": {
+              "type": "array", "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["identity_id", "score"],
+                "properties": {
+                  "identity_id": {"$ref": "#/$defs/id"},
+                  "score": {"type": "number", "minimum": 0, "maximum": 1},
+                  "features": {"type": "object"}
+                }
+              }
+            }
+          },
+          "required": ["mention_id", "candidates"]
+        }
+      ]
+    },
+    "decision": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {
+            "type": {"const": "decision"},
+            "hypothesis_id": {"$ref": "#/$defs/id"},
+            "candidate_id": {"$ref": "#/$defs/id"},
+            "status": {"enum": ["accepted", "rejected", "superseded", "disputed"]},
+            "activity_id": {"$ref": "#/$defs/id"},
+            "comment": {"type": "string"}
+          },
+          "required": ["hypothesis_id", "candidate_id", "status", "activity_id"]
+        }
+      ]
+    },
+    "activity": {
+      "allOf": [
+        {"$ref": "#/$defs/base"},
+        {
+          "properties": {
+            "type": {"const": "activity"},
+            "activity_kind": {"enum": ["ingestion", "extraction", "review", "migration"]},
+            "agent": {"type": "string"},
+            "started_at": {"type": "string", "format": "date-time"},
+            "adapter_version": {"type": ["string", "null"]}
+          },
+          "required": ["activity_kind", "agent", "started_at"]
+        }
+      ]
+    }
+  }
+}

--- a/scripts/evidence_model.py
+++ b/scripts/evidence_model.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Operational helpers for the evidence-first v1 canonical contract."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "1.0.0"
+OBJECT_TYPES = {
+    "source_work", "manifestation", "snapshot", "passage", "mention", "assertion",
+    "person", "group", "identity_hypothesis", "decision", "activity",
+}
+
+
+class EvidenceContractError(ValueError):
+    pass
+
+
+def stable_id(kind: str, *parts: str) -> str:
+    """Deterministic local ID; source-native IDs remain separate properties."""
+    if kind not in OBJECT_TYPES:
+        raise EvidenceContractError(f"unknown object type: {kind}")
+    digest = hashlib.sha256("\x1f".join(parts).encode()).hexdigest()[:24]
+    return f"outremer:{kind}:{digest}"
+
+
+def object_index(dataset: dict) -> dict[str, dict]:
+    return {obj["id"]: obj for obj in dataset.get("objects", [])}
+
+
+def validate_dataset(dataset: dict) -> list[str]:
+    errors: list[str] = []
+    if dataset.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    objects = dataset.get("objects")
+    if not isinstance(objects, list):
+        return errors + ["objects must be an array"]
+    ids = [obj.get("id") for obj in objects]
+    if None in ids or len(ids) != len(set(ids)):
+        errors.append("object ids must be present and unique")
+    index = object_index(dataset)
+    for obj in objects:
+        kind = obj.get("type")
+        if kind not in OBJECT_TYPES:
+            errors.append(f"{obj.get('id')}: unknown type {kind}")
+            continue
+        if not isinstance(obj.get("version"), int) or obj["version"] < 1:
+            errors.append(f"{obj['id']}: version must be a positive integer")
+        if obj.get("supersedes") and obj["supersedes"] not in index:
+            errors.append(f"{obj['id']}: missing superseded object")
+        if kind == "passage" and obj.get("snapshot_id") not in index:
+            errors.append(f"{obj['id']}: passage requires snapshot")
+        if kind == "mention":
+            if obj.get("passage_id") not in index:
+                errors.append(f"{obj['id']}: mention requires passage")
+            if not obj.get("verbatim"):
+                errors.append(f"{obj['id']}: mention requires verbatim text")
+        if kind == "assertion":
+            passages = obj.get("passage_ids", [])
+            if not passages or any(item not in index for item in passages):
+                errors.append(f"{obj['id']}: assertion requires evidence passage(s)")
+        if kind == "identity_hypothesis":
+            if obj.get("mention_id") not in index:
+                errors.append(f"{obj['id']}: hypothesis requires mention")
+            for candidate in obj.get("candidates", []):
+                if candidate.get("identity_id") not in index:
+                    errors.append(f"{obj['id']}: unknown identity candidate")
+        if kind == "decision":
+            for field in ("hypothesis_id", "candidate_id", "activity_id"):
+                if obj.get(field) not in index:
+                    errors.append(f"{obj['id']}: decision requires {field}")
+    return errors
+
+
+def import_snapshot(
+    dataset: dict, snapshot: dict, generated_objects: list[dict]
+) -> dict:
+    """Idempotently add a snapshot and its objects without merging identities."""
+    existing = object_index(dataset)
+    snapshot_id = snapshot["id"]
+    if snapshot_id in existing:
+        if existing[snapshot_id].get("checksum") != snapshot.get("checksum"):
+            raise EvidenceContractError("snapshot id reused with a different checksum")
+        return dataset
+    additions = [snapshot, *generated_objects]
+    duplicate = set(existing) & {obj["id"] for obj in additions}
+    if duplicate:
+        raise EvidenceContractError(f"generated ids already exist: {sorted(duplicate)}")
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "objects": [*dataset.get("objects", []), *additions],
+    }
+    errors = validate_dataset(result)
+    if errors:
+        raise EvidenceContractError("; ".join(errors))
+    return result
+
+
+def canonical_bytes(dataset: dict) -> bytes:
+    return (json.dumps(dataset, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            + "\n").encode()
+
+
+def load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/scripts/migrate_evidence_model.py
+++ b/scripts/migrate_evidence_model.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Read-only migration inventory for the evidence-first v1 contract."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def file_sha256(path: Path) -> str | None:
+    return hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else None
+
+
+def count_records(path: Path) -> int:
+    if not path.exists():
+        return 0
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(value, list):
+        return len(value)
+    if isinstance(value, dict):
+        for key in ("persons", "records", "objects"):
+            if isinstance(value.get(key), list):
+                return len(value[key])
+        return len(value)
+    return 0
+
+
+def dry_run(root: Path = ROOT) -> dict:
+    decisions = root / "data" / "decisions.json"
+    before = file_sha256(decisions)
+    inputs = {
+        "authority": root / "scripts" / "outremer_index.json",
+        "wikidata": root / "site" / "data" / "wikidata_matches.json",
+        "extractions": root / "site" / "index.json",
+        "dhi_quarantine": root / "data" / "dhi" / "dhi_sample_output.json",
+        "fmg_quarantine": root / "data" / "fmg" / "fmg_medlands_crusaders.json",
+    }
+    mappings = {
+        name: {
+            "path": path.relative_to(root).as_posix(),
+            "records": count_records(path),
+            "target_objects": [
+                "source_work", "manifestation", "snapshot", "passage", "mention",
+                "assertion", "identity_hypothesis",
+            ],
+            "quarantined": "quarantine" in name,
+        }
+        for name, path in inputs.items()
+    }
+    after = file_sha256(decisions)
+    return {
+        "mode": "dry-run",
+        "schema_version": "1.0.0",
+        "mappings": mappings,
+        "decisions_sha256_before": before,
+        "decisions_sha256_after": after,
+        "decisions_unchanged": before == after,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    report = dry_run()
+    text = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    print(text, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evidence_model.py
+++ b/tests/test_evidence_model.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.evidence_model import (
+    EvidenceContractError,
+    canonical_bytes,
+    import_snapshot,
+    stable_id,
+    validate_dataset,
+)
+from scripts.migrate_evidence_model import dry_run
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "fixtures" / "evidence-first" / "representative.json"
+
+
+def fixture():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_representative_fixture_covers_contract_and_is_valid():
+    data = fixture()
+    assert validate_dataset(data) == []
+    types = {obj["type"] for obj in data["objects"]}
+    assert {
+        "source_work", "manifestation", "snapshot", "passage", "mention",
+        "assertion", "person", "group", "identity_hypothesis", "decision",
+    } <= types
+
+
+def test_every_assertion_has_precise_snapshot_backed_evidence():
+    data = fixture()
+    index = {obj["id"]: obj for obj in data["objects"]}
+    for assertion in (obj for obj in data["objects"] if obj["type"] == "assertion"):
+        for passage_id in assertion["passage_ids"]:
+            passage = index[passage_id]
+            assert passage["locator"]
+            assert index[passage["snapshot_id"]]["type"] == "snapshot"
+
+
+def test_mentions_keep_verbatim_language_and_script():
+    mention = next(obj for obj in fixture()["objects"] if obj["id"].endswith(":baldwin"))
+    assert mention["verbatim"] == "Baldwin"
+    assert mention["language"] == "en"
+    assert mention["script"] == "Latn"
+
+
+def test_rejected_and_superseded_decisions_preserve_history():
+    data = fixture()
+    statuses = [obj["status"] for obj in data["objects"] if obj["type"] == "decision"]
+    assert {"accepted", "rejected", "superseded"} <= set(statuses)
+    assert any(obj.get("supersedes") for obj in data["objects"])
+
+
+def test_importing_same_snapshot_twice_is_byte_idempotent():
+    empty = {"schema_version": "1.0.0", "objects": []}
+    snapshot = {
+        "id": stable_id("snapshot", "source", "sha"),
+        "type": "snapshot", "version": 1,
+        "manifestation_id": stable_id("manifestation", "source"),
+        "checksum": "a" * 64, "retrieved_at": "2026-07-26T00:00:00Z",
+        "source_locator": "source.json",
+    }
+    manifestation = {
+        "id": snapshot["manifestation_id"], "type": "manifestation", "version": 1,
+        "work_id": stable_id("source_work", "work"), "citation": "Fixture",
+    }
+    work = {
+        "id": manifestation["work_id"], "type": "source_work", "version": 1,
+        "title": "Fixture work",
+    }
+    once = import_snapshot(empty, snapshot, [work, manifestation])
+    twice = import_snapshot(once, snapshot, [work, manifestation])
+    assert canonical_bytes(once) == canonical_bytes(twice)
+
+
+def test_snapshot_id_cannot_be_reused_for_other_content():
+    data = fixture()
+    snapshot = next(obj for obj in data["objects"] if obj["type"] == "snapshot")
+    changed = {**snapshot, "checksum": "f" * 64}
+    with pytest.raises(EvidenceContractError, match="different checksum"):
+        import_snapshot(data, changed, [])
+
+
+def test_migration_dry_run_maps_all_current_structures_without_writing_decisions():
+    report = dry_run(ROOT)
+    assert set(report["mappings"]) == {
+        "authority", "wikidata", "extractions", "dhi_quarantine", "fmg_quarantine",
+    }
+    assert report["decisions_unchanged"] is True
+    assert report["decisions_sha256_before"] == report["decisions_sha256_after"]


### PR DESCRIPTION
Closes #49.

## What changed

- Added versioned evidence-first JSON Schema v1.
- Separated works, manifestations, snapshots, passages, mentions, assertions, persons/groups, identity hypotheses, activities, and decisions.
- Added deterministic local identifier rules while preserving source-native IDs separately.
- Added immutable rejection, dispute, supersession, and tombstone semantics.
- Added representative PDF, structured-authority, contradiction, anonymous/group, and unresolved-two-candidate fixtures.
- Added idempotent snapshot import that refuses checksum reuse and never silently merges identities.
- Added a read-only migration inventory for authority, Wikidata, extraction, quarantined DHI, and quarantined FMG structures.

## Verification

- 93 tests passed
- Migration dry run mapped 781 current records
- `data/decisions.json` SHA-256 unchanged before/after
- Ruff and `git diff --check`: clean
