### PR TITLE
M11.2: model provenance, uncertainty, temporal bounds, and place

### DIFF
--- a/docs/PROVENANCE_UNCERTAINTY.md
+++ b/docs/PROVENANCE_UNCERTAINTY.md
@@ -1,0 +1,27 @@
+# Provenance, uncertainty, time and place
+
+The v1 semantics keep distinct fields for:
+
+- source wording and `source_certainty`
+- polarity (`affirmed`, `negated`, `disputed`)
+- inference (`source_explicit`, `source_implicit`, `extracted`, `editorial_inference`)
+- source reliability (`high`, `medium`, `low`, `unassessed`)
+- extractor confidence, reconciliation score, and editorial confidence
+- review status (`unreviewed`, `accepted`, `rejected`, `disputed`, `superseded`)
+
+These dimensions must not be collapsed into one confidence number.
+
+Assertion time is separate from source creation/publication, ingestion,
+generation, and review times. It supports `when`, `from/to`,
+`notBefore/notAfter`, open intervals, original textual dating, and calendar or
+normalization notes.
+
+Place strings remain attached to assertions. Ranked place candidates preserve
+their own URI, temporal scope, geometry, and spatial precision. No candidate is
+required, and multiple candidates may remain unresolved.
+
+RDF uses PROV-O for snapshots, generation and review activities; CIDOC
+CRM/CRMinf-compatible assertion resources; SKOS-like controlled terms; and
+GeoSPARQL WKT for geometry. `schema/evidence-first-v1.shacl.ttl` rejects missing
+evidence, malformed ranges, invalid decision status, and accepted identity
+decisions without a reviewer-bearing review activity.

--- a/fixtures/evidence-first/uncertainty.json
+++ b/fixtures/evidence-first/uncertainty.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "1.0.0",
+  "objects": [
+    {"id":"outremer:snapshot:chronicle","type":"snapshot","version":1,"manifestation_id":"outremer:manifestation:chronicle","checksum":"2222222222222222222222222222222222222222222222222222222222222222","retrieved_at":"2026-07-26T08:00:00Z","source_locator":"chronicle.xml","source_created_at":"1175-01-01T00:00:00Z","source_published_at":"1899-01-01T00:00:00Z","ingested_at":"2026-07-26T08:00:00Z"},
+    {"id":"outremer:passage:chronicle-44","type":"passage","version":1,"snapshot_id":"outremer:snapshot:chronicle","locator":"folio 22r, lines 4–8","text":"He perhaps came to Jerusalem between 1160 and 1170."},
+    {"id":"outremer:activity:extract-1","type":"activity","version":1,"activity_kind":"extraction","agent":"adapter-syriaca","started_at":"2026-07-26T08:00:01Z","adapter_version":"syriaca-tei-v1"},
+    {"id":"outremer:activity:review-3","type":"activity","version":1,"activity_kind":"review","agent":"reviewer-gamma","started_at":"2026-07-26T09:00:00Z","adapter_version":null},
+    {
+      "id":"outremer:assertion:uncertain-visit",
+      "type":"assertion",
+      "version":1,
+      "passage_ids":["outremer:passage:chronicle-44"],
+      "subject_id":"outremer:person:visitor",
+      "predicate":"visited",
+      "object":"Jerusalem",
+      "semantics":{
+        "source_certainty":"possible",
+        "polarity":"affirmed",
+        "inference":"source_explicit",
+        "source_reliability":"medium",
+        "review_status":"disputed",
+        "extractor_confidence":0.88,
+        "reconciliation_score":0.61,
+        "editorial_confidence":0.55
+      },
+      "asserted_time":{
+        "notBefore":1160,
+        "notAfter":1170,
+        "original_text":"between the twentieth and thirtieth year of the reign",
+        "calendar_note":"normalized approximately to CE from the source regnal dating"
+      },
+      "place_candidates":[
+        {"source_string":"Jerusalem","uri":"https://pleiades.stoa.org/places/687928","rank":1,"valid_from":-500,"valid_to":700,"geometry":"POINT(35.2167 31.7833)","spatial_precision":"settlement-centroid"},
+        {"source_string":"Jerusalem","uri":"https://www.wikidata.org/entity/Q1218","rank":2,"valid_from":1000,"valid_to":1400,"geometry":null,"spatial_precision":"city"}
+      ],
+      "provenance":{
+        "snapshot_id":"outremer:snapshot:chronicle",
+        "generation_activity_id":"outremer:activity:extract-1",
+        "review_activity_id":"outremer:activity:review-3"
+      }
+    },
+    {"id":"outremer:decision:identity-accepted","type":"decision","version":1,"hypothesis_id":"outremer:identity_hypothesis:visitor","candidate_id":"outremer:person:visitor","status":"accepted","activity_id":"outremer:activity:review-3"}
+  ]
+}

--- a/queries/conflicting_assertions.rq
+++ b/queries/conflicting_assertions.rq
@@ -1,0 +1,6 @@
+PREFIX out: <https://outremer.example/ns/>
+SELECT ?left ?right WHERE {
+  ?left a out:Assertion ; out:predicate ?predicate ; out:assertionObject ?object .
+  ?right a out:Assertion ; out:predicate ?predicate ; out:assertionObject ?other .
+  FILTER (?left != ?right && ?object != ?other)
+}

--- a/queries/evidence_for_person.rq
+++ b/queries/evidence_for_person.rq
@@ -1,0 +1,6 @@
+PREFIX out: <https://outremer.example/ns/>
+SELECT ?assertion ?passage WHERE {
+  ?assertion a out:Assertion ;
+             out:evidencePassage ?passage .
+  FILTER EXISTS { ?assertion out:assertionObject ?value }
+}

--- a/queries/place_candidates_for_period.rq
+++ b/queries/place_candidates_for_period.rq
@@ -1,0 +1,8 @@
+PREFIX out: <https://outremer.example/ns/>
+SELECT ?assertion ?candidate ?place WHERE {
+  ?assertion a out:Assertion ; out:placeCandidate ?candidate .
+  ?candidate out:candidateUri ?place .
+  OPTIONAL { ?candidate out:validFrom ?from }
+  OPTIONAL { ?candidate out:validTo ?to }
+  FILTER ((!BOUND(?from) || ?from <= 1200) && (!BOUND(?to) || ?to >= 1100))
+}

--- a/queries/uncertain_participation.rq
+++ b/queries/uncertain_participation.rq
@@ -1,0 +1,7 @@
+PREFIX out: <https://outremer.example/ns/>
+SELECT ?assertion ?certainty WHERE {
+  ?assertion a out:Assertion ;
+             out:predicate "participated_in" ;
+             out:source_certainty ?certainty .
+  FILTER (?certainty != "certain")
+}

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -26,3 +26,5 @@ tqdm==4.69.0
 typing-inspection==0.4.2
 typing_extensions==4.16.0
 zipp==4.1.0
+rdflib==7.6.0
+pyshacl==0.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ python-dotenv>=1.0  # load .env.gpustack for GPUStack config
 # MISTRAL_API_KEY is set; or force it with OCR_ENGINE=mistral).
 # Install via: pip install -e '.[ocr-mistral]'   (or: pip install mistralai)
 # Kept in requirements.lock.txt so the nightly pipeline retains the fallback.
+rdflib==7.6.0
+pyshacl==0.31.0

--- a/schema/evidence-first-v1.shacl.ttl
+++ b/schema/evidence-first-v1.shacl.ttl
@@ -1,0 +1,44 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix out: <https://outremer.example/ns/> .
+
+out:AssertionShape
+    a sh:NodeShape ;
+    sh:targetClass out:Assertion ;
+    sh:property [
+        sh:path out:evidencePassage ;
+        sh:minCount 1 ;
+        sh:class out:Passage ;
+        sh:message "Every assertion requires an evidence passage." ;
+    ] ;
+    sh:sparql [
+        sh:message "Temporal notBefore must not be later than notAfter." ;
+        sh:select """
+            SELECT $this WHERE {
+              $this out:notBefore ?start ; out:notAfter ?end .
+              FILTER (?start > ?end)
+            }
+        """ ;
+    ] .
+
+out:DecisionShape
+    a sh:NodeShape ;
+    sh:targetClass out:Decision ;
+    sh:property [
+        sh:path out:decisionStatus ;
+        sh:minCount 1 ;
+        sh:in ("accepted" "rejected" "superseded" "disputed") ;
+        sh:message "Decision status must use the controlled vocabulary." ;
+    ] ;
+    sh:sparql [
+        sh:message "Accepted identity decisions require reviewer and review activity provenance." ;
+        sh:select """
+            SELECT $this WHERE {
+              $this out:decisionStatus "accepted" .
+              FILTER NOT EXISTS {
+                $this out:reviewActivity ?activity .
+                ?activity out:responsibleAgent ?reviewer .
+              }
+            }
+        """ ;
+    ] .

--- a/scripts/evidence_semantics.py
+++ b/scripts/evidence_semantics.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""RDF/JSON-LD projection for assertion-level evidence and uncertainty."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from pyshacl import validate
+from rdflib import RDF, XSD, BNode, Graph, Literal, Namespace, URIRef
+
+OUT = Namespace("https://outremer.example/ns/")
+PROV = Namespace("http://www.w3.org/ns/prov#")
+CRM = Namespace("http://www.cidoc-crm.org/cidoc-crm/")
+CRMINF = Namespace("http://www.cidoc-crm.org/crminf/")
+GEO = Namespace("http://www.opengis.net/ont/geosparql#")
+BASE = "https://outremer.example/id/"
+SHAPES = Path(__file__).resolve().parents[1] / "schema" / "evidence-first-v1.shacl.ttl"
+
+CERTAINTY = {"certain", "probable", "possible", "unlikely", "unknown"}
+POLARITY = {"affirmed", "negated", "disputed"}
+REVIEW_STATUS = {"unreviewed", "accepted", "rejected", "disputed", "superseded"}
+INFERENCE = {"source_explicit", "source_implicit", "extracted", "editorial_inference"}
+RELIABILITY = {"high", "medium", "low", "unassessed"}
+
+
+def uri(local_id: str) -> URIRef:
+    return URIRef(BASE + local_id.replace("outremer:", "").replace(":", "/"))
+
+
+def _literal_year(value: int | None) -> Literal | None:
+    return Literal(value, datatype=XSD.integer) if value is not None else None
+
+
+def _add_optional(graph: Graph, subject, predicate, value) -> None:
+    if value is not None:
+        graph.add((subject, predicate, value))
+
+
+def dataset_to_graph(dataset: dict) -> Graph:
+    graph = Graph()
+    graph.bind("out", OUT)
+    graph.bind("prov", PROV)
+    graph.bind("crm", CRM)
+    graph.bind("crminf", CRMINF)
+    graph.bind("geo", GEO)
+    index = {obj["id"]: obj for obj in dataset["objects"]}
+    for obj in dataset["objects"]:
+        subject = uri(obj["id"])
+        kind = obj["type"]
+        class_name = {
+            "assertion": "Assertion", "passage": "Passage", "decision": "Decision",
+            "activity": "Activity", "snapshot": "Snapshot", "person": "Person",
+            "group": "Group", "mention": "Mention", "identity_hypothesis": "IdentityHypothesis",
+        }.get(kind, kind.title().replace("_", ""))
+        graph.add((subject, RDF.type, OUT[class_name]))
+        graph.add((subject, OUT.localId, Literal(obj["id"])))
+
+        if kind == "assertion":
+            for passage_id in obj.get("passage_ids", []):
+                graph.add((subject, OUT.evidencePassage, uri(passage_id)))
+            graph.add((subject, OUT.predicate, Literal(obj.get("predicate", ""))))
+            graph.add((subject, OUT.assertionObject, Literal(str(obj.get("object", "")))))
+            semantics = obj.get("semantics", {})
+            for key, allowed in (
+                ("source_certainty", CERTAINTY), ("polarity", POLARITY),
+                ("inference", INFERENCE), ("source_reliability", RELIABILITY),
+                ("review_status", REVIEW_STATUS),
+            ):
+                value = semantics.get(key)
+                if value not in allowed:
+                    raise ValueError(f"{obj['id']}: invalid {key} {value!r}")
+                graph.add((subject, OUT[key], Literal(value)))
+            for key in ("extractor_confidence", "reconciliation_score", "editorial_confidence"):
+                _add_optional(
+                    graph, subject, OUT[key],
+                    Literal(semantics[key], datatype=XSD.decimal) if key in semantics else None,
+                )
+            temporal = obj.get("asserted_time", {})
+            for key in ("notBefore", "notAfter", "from", "to", "when"):
+                _add_optional(graph, subject, OUT[key], _literal_year(temporal.get(key)))
+            _add_optional(
+                graph, subject, OUT.originalDateText,
+                Literal(temporal["original_text"]) if temporal.get("original_text") else None,
+            )
+            _add_optional(
+                graph, subject, OUT.calendarNote,
+                Literal(temporal["calendar_note"]) if temporal.get("calendar_note") else None,
+            )
+            for candidate in obj.get("place_candidates", []):
+                node = BNode()
+                graph.add((subject, OUT.placeCandidate, node))
+                graph.add((node, OUT.sourceString, Literal(candidate["source_string"])))
+                graph.add((node, OUT.candidateUri, URIRef(candidate["uri"])))
+                graph.add((node, OUT.rank, Literal(candidate["rank"], datatype=XSD.integer)))
+                _add_optional(graph, node, OUT.validFrom, _literal_year(candidate.get("valid_from")))
+                _add_optional(graph, node, OUT.validTo, _literal_year(candidate.get("valid_to")))
+                _add_optional(
+                    graph, node, GEO.asWKT,
+                    Literal(candidate["geometry"], datatype=GEO.wktLiteral)
+                    if candidate.get("geometry") else None,
+                )
+                graph.add((node, OUT.spatialPrecision, Literal(candidate["spatial_precision"])))
+            provenance = obj.get("provenance", {})
+            graph.add((subject, PROV.wasDerivedFrom, uri(provenance["snapshot_id"])))
+            graph.add((subject, PROV.wasGeneratedBy, uri(provenance["generation_activity_id"])))
+            if provenance.get("review_activity_id"):
+                graph.add((subject, OUT.reviewActivity, uri(provenance["review_activity_id"])))
+
+        if kind == "snapshot":
+            for field in ("source_created_at", "source_published_at", "ingested_at"):
+                if obj.get(field):
+                    graph.add((subject, OUT[field], Literal(obj[field], datatype=XSD.dateTime)))
+
+        if kind == "activity":
+            graph.add((subject, OUT.responsibleAgent, Literal(obj["agent"])))
+            graph.add((subject, PROV.startedAtTime, Literal(obj["started_at"], datatype=XSD.dateTime)))
+            if obj.get("adapter_version"):
+                graph.add((subject, OUT.adapterVersion, Literal(obj["adapter_version"])))
+
+        if kind == "decision":
+            graph.add((subject, OUT.decisionStatus, Literal(obj["status"])))
+            graph.add((subject, OUT.reviewActivity, uri(obj["activity_id"])))
+            activity = index.get(obj["activity_id"])
+            if activity:
+                activity_uri = uri(activity["id"])
+                graph.add((activity_uri, RDF.type, OUT.Activity))
+                graph.add((activity_uri, OUT.responsibleAgent, Literal(activity["agent"])))
+    return graph
+
+
+def assertion_from_graph(graph: Graph, assertion_id: str) -> dict[str, Any]:
+    subject = uri(assertion_id)
+
+    def value(predicate):
+        item = graph.value(subject, predicate)
+        return item.toPython() if item is not None else None
+
+    asserted_time = {
+        key: value(OUT[key])
+        for key in ("notBefore", "notAfter", "from", "to", "when")
+        if value(OUT[key]) is not None
+    }
+    if value(OUT.originalDateText):
+        asserted_time["original_text"] = value(OUT.originalDateText)
+    if value(OUT.calendarNote):
+        asserted_time["calendar_note"] = value(OUT.calendarNote)
+    candidates = []
+    for node in graph.objects(subject, OUT.placeCandidate):
+        candidates.append({
+            "source_string": graph.value(node, OUT.sourceString).toPython(),
+            "uri": str(graph.value(node, OUT.candidateUri)),
+            "rank": graph.value(node, OUT.rank).toPython(),
+            "valid_from": (
+                graph.value(node, OUT.validFrom).toPython()
+                if graph.value(node, OUT.validFrom) else None
+            ),
+            "valid_to": (
+                graph.value(node, OUT.validTo).toPython()
+                if graph.value(node, OUT.validTo) else None
+            ),
+            "geometry": (
+                str(graph.value(node, GEO.asWKT)) if graph.value(node, GEO.asWKT) else None
+            ),
+            "spatial_precision": graph.value(node, OUT.spatialPrecision).toPython(),
+        })
+    return {
+        "id": assertion_id,
+        "passage_ids": [
+            str(item).replace(BASE, "outremer:").replace("/", ":", 1)
+            for item in graph.objects(subject, OUT.evidencePassage)
+        ],
+        "semantics": {
+            key: value(OUT[key])
+            for key in (
+                "source_certainty", "polarity", "inference", "source_reliability",
+                "review_status", "extractor_confidence", "reconciliation_score",
+                "editorial_confidence",
+            )
+            if value(OUT[key]) is not None
+        },
+        "asserted_time": asserted_time,
+        "place_candidates": sorted(candidates, key=lambda item: item["rank"]),
+        "provenance": {
+            "snapshot_uri": str(graph.value(subject, PROV.wasDerivedFrom)),
+            "generation_activity_uri": str(graph.value(subject, PROV.wasGeneratedBy)),
+            "review_activity_uri": (
+                str(graph.value(subject, OUT.reviewActivity))
+                if graph.value(subject, OUT.reviewActivity) else None
+            ),
+        },
+    }
+
+
+def validate_graph(graph: Graph, shapes_path: Path = SHAPES) -> tuple[bool, str]:
+    conforms, _, report = validate(
+        graph, shacl_graph=str(shapes_path), inference="rdfs", advanced=True
+    )
+    return bool(conforms), str(report)
+
+
+def parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/tests/test_evidence_semantics.py
+++ b/tests/test_evidence_semantics.py
@@ -1,0 +1,106 @@
+import json
+from pathlib import Path
+
+from rdflib import Literal
+
+from scripts.evidence_semantics import (
+    OUT,
+    assertion_from_graph,
+    dataset_to_graph,
+    uri,
+    validate_graph,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "fixtures" / "evidence-first" / "uncertainty.json"
+
+
+def fixture():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_time_uncertainty_place_and_provenance_round_trip():
+    data = fixture()
+    graph = dataset_to_graph(data)
+    restored = assertion_from_graph(graph, "outremer:assertion:uncertain-visit")
+    source = next(obj for obj in data["objects"] if obj["type"] == "assertion")
+    assert restored["semantics"] == source["semantics"]
+    assert restored["asserted_time"] == source["asserted_time"]
+    assert restored["place_candidates"] == source["place_candidates"]
+    assert restored["provenance"]["snapshot_uri"].endswith("/snapshot/chronicle")
+    assert restored["provenance"]["review_activity_uri"].endswith("/activity/review-3")
+
+
+def test_date_bounds_survive_jsonld_and_turtle_serialization():
+    source_graph = dataset_to_graph(fixture())
+    for format_name in ("json-ld", "turtle"):
+        serialized = source_graph.serialize(format=format_name)
+        restored_graph = type(source_graph)().parse(data=serialized, format=format_name)
+        restored = assertion_from_graph(
+            restored_graph, "outremer:assertion:uncertain-visit"
+        )
+        assert restored["asserted_time"]["notBefore"] == 1160
+        assert restored["asserted_time"]["notAfter"] == 1170
+        assert "twentieth and thirtieth year" in restored["asserted_time"]["original_text"]
+        assert "regnal dating" in restored["asserted_time"]["calendar_note"]
+
+
+def test_source_assertion_ingestion_and_review_times_remain_distinct():
+    data = fixture()
+    snapshot = data["objects"][0]
+    extraction = data["objects"][2]
+    review = data["objects"][3]
+    assertion = data["objects"][4]
+    assert assertion["asserted_time"]["notBefore"] == 1160
+    assert snapshot["source_created_at"].startswith("1175")
+    assert snapshot["ingested_at"].startswith("2026-07-26T08")
+    assert extraction["started_at"].startswith("2026-07-26T08")
+    assert review["started_at"].startswith("2026-07-26T09")
+
+
+def test_valid_fixture_conforms_to_shacl():
+    conforms, report = validate_graph(dataset_to_graph(fixture()))
+    assert conforms, report
+
+
+def test_shacl_rejects_assertion_without_evidence():
+    graph = dataset_to_graph(fixture())
+    assertion = uri("outremer:assertion:uncertain-visit")
+    graph.remove((assertion, OUT.evidencePassage, None))
+    conforms, report = validate_graph(graph)
+    assert not conforms
+    assert "requires an evidence passage" in report
+
+
+def test_shacl_rejects_malformed_range():
+    graph = dataset_to_graph(fixture())
+    assertion = uri("outremer:assertion:uncertain-visit")
+    graph.set((assertion, OUT.notBefore, Literal(1200)))
+    graph.set((assertion, OUT.notAfter, Literal(1100)))
+    conforms, report = validate_graph(graph)
+    assert not conforms
+    assert "notBefore" in report
+
+
+def test_shacl_rejects_untyped_decision_status():
+    graph = dataset_to_graph(fixture())
+    decision = uri("outremer:decision:identity-accepted")
+    graph.set((decision, OUT.decisionStatus, Literal("maybe")))
+    conforms, report = validate_graph(graph)
+    assert not conforms
+    assert "controlled vocabulary" in report
+
+
+def test_shacl_rejects_accepted_decision_without_reviewer_provenance():
+    graph = dataset_to_graph(fixture())
+    activity = uri("outremer:activity:review-3")
+    graph.remove((activity, OUT.responsibleAgent, None))
+    conforms, report = validate_graph(graph)
+    assert not conforms
+    assert "require reviewer" in report
+
+
+def test_all_competency_queries_parse_and_execute():
+    graph = dataset_to_graph(fixture())
+    for path in sorted((ROOT / "queries").glob("*.rq")):
+        list(graph.query(path.read_text(encoding="utf-8")))


### PR DESCRIPTION
Closes #50.

## What changed

- Added controlled, independent dimensions for source certainty, polarity, inference, source reliability, extractor confidence, reconciliation score, editorial confidence, and review status.
- Separated assertion time from source creation/publication, ingestion, generation, and review times.
- Preserved bounded/open temporal intervals, original textual dating, and calendar-normalization notes.
- Added unresolved/ranked place candidates with temporal scope, geometry, provenance, and spatial precision.
- Added PROV-O lineage for snapshots, adapter/generation activity, responsible agents, and review activity.
- Added SHACL shapes rejecting missing evidence, malformed ranges, invalid decision status, and accepted decisions without reviewer provenance.
- Added four evidence-first competency queries.

## Verification

- 102 tests passed
- JSON-LD and Turtle round-trip temporal bounds and original dating without loss
- Valid fixture passes SHACL; four deliberately broken cases fail
- Offline agreement remains 0.9155
- Ruff and `git diff --check`: clean
