### PR TITLE
M11.3: publish auditable evidence and extend review

### DIFF
--- a/docs/AUDITABLE_PUBLICATION.md
+++ b/docs/AUDITABLE_PUBLICATION.md
@@ -1,0 +1,27 @@
+# Auditable publication profiles and review
+
+Run:
+
+```bash
+python3 scripts/evidence_publish.py fixtures/evidence-first/representative.json /tmp/outremer-publication
+```
+
+The versioned outputs are canonical JSON, lossless JSON-LD, Turtle, a clearly
+labelled lossy schema.org discovery projection, and TEI stand-off mention links.
+Every graph resource has a stable `https://outremer.example/id/...` URI.
+Assertion and decision triples expose evidence and provenance; an embedded
+canonical representation guarantees exact round-trip of locators, uncertainty,
+temporal bounds, candidate scores, rejected decisions, and history.
+
+`owl:sameAs` is emitted only when an accepted decision explicitly carries
+`same_as_assertion: true`; imported identifiers or fuzzy scores cannot trigger
+it.
+
+The static `site/evidence-review.html` interface reviews both assertions and
+identity hypotheses. Accept, reject, flag, comment, and supersede operations
+create append-only JSONL decisions with pseudonymous reviewers and timestamps.
+Concurrent accept/reject or accept/flag decisions remain visibly conflicted.
+Source passages and imported records are never modified.
+
+The existing `data/decisions.json` is outside this workflow and remains
+untouched until an explicit reviewed migration.

--- a/scripts/evidence_publish.py
+++ b/scripts/evidence_publish.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Versioned canonical, JSON-LD, Turtle, schema.org and TEI publication profiles."""
+from __future__ import annotations
+
+import argparse
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from rdflib import RDF, Graph, Literal, Namespace, URIRef
+
+try:
+    from scripts.evidence_model import canonical_bytes, validate_dataset
+    from scripts.evidence_semantics import OUT, PROV, uri
+except ModuleNotFoundError:  # direct ``python scripts/evidence_publish.py``
+    from evidence_model import canonical_bytes, validate_dataset
+    from evidence_semantics import OUT, PROV, uri
+
+OWL = Namespace("http://www.w3.org/2002/07/owl#")
+SCHEMA = Namespace("https://schema.org/")
+TEI = "http://www.tei-c.org/ns/1.0"
+PROFILE_VERSION = "1.0.0"
+
+
+def publication_graph(dataset: dict) -> Graph:
+    """Lossless graph: semantic triples plus canonical JSON for exact round-trip."""
+    errors = validate_dataset(dataset)
+    if errors:
+        raise ValueError("; ".join(errors))
+    graph = Graph()
+    graph.bind("out", OUT)
+    graph.bind("prov", PROV)
+    graph.bind("schema", SCHEMA)
+    graph.bind("owl", OWL)
+    index = {obj["id"]: obj for obj in dataset["objects"]}
+    for obj in dataset["objects"]:
+        subject = uri(obj["id"])
+        graph.add((subject, RDF.type, OUT[obj["type"].title().replace("_", "")]))
+        graph.add((subject, OUT.localId, Literal(obj["id"])))
+        graph.add((subject, OUT.profileVersion, Literal(PROFILE_VERSION)))
+        graph.add((
+            subject,
+            OUT.canonicalJson,
+            Literal(json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))),
+        ))
+        if obj["type"] == "passage":
+            graph.add((subject, OUT.snapshot, uri(obj["snapshot_id"])))
+            graph.add((subject, OUT.locator, Literal(obj["locator"])))
+        elif obj["type"] == "mention":
+            graph.add((subject, OUT.passage, uri(obj["passage_id"])))
+            graph.add((subject, OUT.verbatim, Literal(obj["verbatim"])))
+        elif obj["type"] == "assertion":
+            for passage_id in obj["passage_ids"]:
+                graph.add((subject, OUT.evidencePassage, uri(passage_id)))
+            graph.add((subject, OUT.subject, uri(obj["subject_id"])))
+            graph.add((subject, OUT.predicate, Literal(obj["predicate"])))
+        elif obj["type"] == "identity_hypothesis":
+            graph.add((subject, OUT.mention, uri(obj["mention_id"])))
+            for candidate in obj["candidates"]:
+                graph.add((subject, OUT.candidate, uri(candidate["identity_id"])))
+        elif obj["type"] == "decision":
+            graph.add((subject, OUT.hypothesis, uri(obj["hypothesis_id"])))
+            graph.add((subject, OUT.candidate, uri(obj["candidate_id"])))
+            graph.add((subject, OUT.decisionStatus, Literal(obj["status"])))
+            graph.add((subject, PROV.wasGeneratedBy, uri(obj["activity_id"])))
+            # owl:sameAs is reserved for an explicit, reviewed scholarly decision.
+            if (
+                obj["status"] == "accepted"
+                and obj.get("same_as_assertion") is True
+                and index[obj["candidate_id"]].get("source_native_ids")
+            ):
+                for external in index[obj["candidate_id"]]["source_native_ids"].values():
+                    if external.startswith("http"):
+                        graph.add((uri(obj["candidate_id"]), OWL.sameAs, URIRef(external)))
+    return graph
+
+
+def graph_to_dataset(graph: Graph) -> dict:
+    objects = [
+        json.loads(str(value))
+        for value in graph.objects(None, OUT.canonicalJson)
+    ]
+    objects.sort(key=lambda obj: obj["id"])
+    return {"schema_version": "1.0.0", "objects": objects}
+
+
+def discovery_projection(dataset: dict) -> dict:
+    """Lossy schema.org projection for discovery only, never canonical reuse."""
+    people = []
+    for obj in dataset["objects"]:
+        if obj["type"] not in {"person", "group"}:
+            continue
+        item = {
+            "@type": "Person" if obj["type"] == "person" else "Organization",
+            "@id": str(uri(obj["id"])),
+            "name": obj["preferred_label"],
+        }
+        people.append(item)
+    return {
+        "@context": "https://schema.org",
+        "@type": "Dataset",
+        "name": "Outremer discovery projection",
+        "description": (
+            "Lossy discovery projection. Consult canonical JSON-LD/Turtle for "
+            "evidence, uncertainty, and decision history."
+        ),
+        "hasPart": people,
+    }
+
+
+def tei_standoff(dataset: dict) -> str:
+    """TEI stand-off annotations linking verbatim mentions to accepted identities."""
+    index = {obj["id"]: obj for obj in dataset["objects"]}
+    accepted: dict[str, str] = {}
+    for decision in dataset["objects"]:
+        if decision["type"] != "decision" or decision["status"] != "accepted":
+            continue
+        hypothesis = index[decision["hypothesis_id"]]
+        accepted[hypothesis["mention_id"]] = decision["candidate_id"]
+    root = ET.Element(f"{{{TEI}}}TEI")
+    text = ET.SubElement(root, f"{{{TEI}}}text")
+    body = ET.SubElement(text, f"{{{TEI}}}body")
+    ET.SubElement(body, f"{{{TEI}}}p").text = (
+        "Stand-off projection; source text remains in canonical passages."
+    )
+    stand_off = ET.SubElement(root, f"{{{TEI}}}standOff")
+    spans = ET.SubElement(stand_off, f"{{{TEI}}}spanGrp", {"type": "outremer-mentions"})
+    for mention in (obj for obj in dataset["objects"] if obj["type"] == "mention"):
+        attributes = {
+            "{http://www.w3.org/XML/1998/namespace}id": mention["id"].replace(":", "-"),
+            "ana": str(uri(mention["id"])),
+        }
+        if mention["id"] in accepted:
+            attributes["ref"] = str(uri(accepted[mention["id"]]))
+        span = ET.SubElement(spans, f"{{{TEI}}}span", attributes)
+        span.text = mention["verbatim"]
+    return ET.tostring(root, encoding="unicode")
+
+
+def publish(dataset: dict, output: Path) -> dict[str, Path]:
+    output.mkdir(parents=True, exist_ok=True)
+    graph = publication_graph(dataset)
+    paths = {
+        "canonical": output / "canonical.json",
+        "jsonld": output / "canonical.jsonld",
+        "turtle": output / "canonical.ttl",
+        "discovery": output / "discovery.schema.json",
+        "tei": output / "mentions.tei.xml",
+    }
+    paths["canonical"].write_bytes(canonical_bytes(dataset))
+    paths["jsonld"].write_text(graph.serialize(format="json-ld", indent=2), encoding="utf-8")
+    paths["turtle"].write_text(graph.serialize(format="turtle"), encoding="utf-8")
+    paths["discovery"].write_text(
+        json.dumps(discovery_projection(dataset), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    paths["tei"].write_text(tei_standoff(dataset), encoding="utf-8")
+    return paths
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dataset", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    publish(json.loads(args.dataset.read_text(encoding="utf-8")), args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evidence_review.py
+++ b/scripts/evidence_review.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Append-only review decisions for assertions and identity hypotheses."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+TARGET_TYPES = {"assertion", "identity_hypothesis"}
+ACTIONS = {"accept", "reject", "flag", "supersede"}
+
+
+def pseudonym(reviewer: str) -> str:
+    return "reviewer-" + hashlib.sha256(reviewer.encode()).hexdigest()[:12]
+
+
+def make_review(
+    *,
+    target_id: str,
+    target_type: str,
+    action: str,
+    reviewer: str,
+    comment: str,
+    supersedes: str | None = None,
+    timestamp: str | None = None,
+) -> dict:
+    if target_type not in TARGET_TYPES:
+        raise ValueError(f"unsupported target type: {target_type}")
+    if action not in ACTIONS:
+        raise ValueError(f"unsupported review action: {action}")
+    if action == "supersede" and not supersedes:
+        raise ValueError("supersede requires the prior decision id")
+    timestamp = timestamp or datetime.now(timezone.utc).isoformat()
+    reviewer_id = pseudonym(reviewer)
+    token = "\x1f".join((target_id, action, reviewer_id, timestamp, supersedes or ""))
+    return {
+        "id": "outremer:review:" + hashlib.sha256(token.encode()).hexdigest()[:24],
+        "target_id": target_id,
+        "target_type": target_type,
+        "action": action,
+        "reviewer": reviewer_id,
+        "timestamp": timestamp,
+        "comment": comment,
+        "supersedes": supersedes,
+    }
+
+
+def append_review(path: Path, review: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(review, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def review_state(reviews: list[dict], target_id: str) -> dict:
+    """Keep concurrent reviewer disagreement visible; never pick a silent winner."""
+    relevant = [review for review in reviews if review["target_id"] == target_id]
+    superseded = {
+        review["supersedes"] for review in relevant if review.get("supersedes")
+    }
+    active = [review for review in relevant if review["id"] not in superseded]
+    actions = {review["action"] for review in active}
+    return {
+        "target_id": target_id,
+        "history": relevant,
+        "active": active,
+        "conflict": "accept" in actions and bool(actions & {"reject", "flag"}),
+    }

--- a/site/evidence-review.html
+++ b/site/evidence-review.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Outremer evidence review</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <h1>Evidence and identity review</h1>
+    <p>Review assertions and identity hypotheses without changing source evidence.</p>
+    <label>Reviewer pseudonym seed <input id="reviewer" autocomplete="off"></label>
+    <label>Canonical dataset <input id="dataset" type="file" accept=".json"></label>
+    <section id="items"></section>
+    <button id="export">Export append-only reviews</button>
+  </main>
+  <script src="evidence-review.js"></script>
+</body>
+</html>

--- a/site/evidence-review.js
+++ b/site/evidence-review.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const reviews = [];
+
+async function digest(text) {
+  const bytes = new TextEncoder().encode(text);
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(hash)].map(x => x.toString(16).padStart(2, "0")).join("");
+}
+
+async function addReview(target, action, supersedes = null) {
+  const reviewerSeed = document.querySelector("#reviewer").value || "anonymous";
+  const reviewer = `reviewer-${(await digest(reviewerSeed)).slice(0, 12)}`;
+  const comment = prompt("Review comment") || "";
+  const timestamp = new Date().toISOString();
+  const id = `outremer:review:${(await digest(
+    [target.id, action, reviewer, timestamp, supersedes || ""].join("\u001f")
+  )).slice(0, 24)}`;
+  reviews.push({
+    id, target_id: target.id, target_type: target.type, action,
+    reviewer, timestamp, comment, supersedes
+  });
+  renderHistory(target.id);
+}
+
+function activeReviews(targetId) {
+  const history = reviews.filter(item => item.target_id === targetId);
+  const superseded = new Set(history.map(item => item.supersedes).filter(Boolean));
+  return history.filter(item => !superseded.has(item.id));
+}
+
+function renderHistory(targetId) {
+  const output = document.querySelector(`[data-history="${CSS.escape(targetId)}"]`);
+  const active = activeReviews(targetId);
+  const actions = new Set(active.map(item => item.action));
+  const conflict = actions.has("accept") && (actions.has("reject") || actions.has("flag"));
+  output.textContent = JSON.stringify({conflict, active, history:
+    reviews.filter(item => item.target_id === targetId)}, null, 2);
+}
+
+function renderItem(target) {
+  const article = document.createElement("article");
+  article.innerHTML = `<h2>${target.type}: ${target.id}</h2>
+    <pre>${JSON.stringify(target, null, 2)}</pre>
+    <div class="actions"></div><pre data-history="${target.id}"></pre>`;
+  for (const action of ["accept", "reject", "flag"]) {
+    const button = document.createElement("button");
+    button.textContent = action;
+    button.onclick = () => addReview(target, action);
+    article.querySelector(".actions").append(button);
+  }
+  const supersede = document.createElement("button");
+  supersede.textContent = "supersede selected prior review";
+  supersede.onclick = () => {
+    const prior = prompt("Prior review ID to supersede");
+    if (prior) addReview(target, "supersede", prior);
+  };
+  article.querySelector(".actions").append(supersede);
+  return article;
+}
+
+document.querySelector("#dataset").addEventListener("change", async event => {
+  const dataset = JSON.parse(await event.target.files[0].text());
+  const items = dataset.objects.filter(item =>
+    ["assertion", "identity_hypothesis"].includes(item.type));
+  const container = document.querySelector("#items");
+  container.replaceChildren(...items.map(renderItem));
+});
+
+document.querySelector("#export").onclick = () => {
+  const blob = new Blob(
+    [reviews.map(item => JSON.stringify(item)).join("\n") + "\n"],
+    {type: "application/x-ndjson"}
+  );
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = "evidence-reviews.jsonl";
+  link.click();
+  URL.revokeObjectURL(link.href);
+};

--- a/site/index.html
+++ b/site/index.html
@@ -105,6 +105,7 @@
     <div class="hero-btns">
       <a class="hero-btn primary" href="./explorer.html">Contribute your Knowledge</a>
       <a class="hero-btn secondary" href="./people.html">👤 People Lookup</a>
+      <a class="hero-btn secondary" href="./evidence-review.html">⚖ Evidence Review</a>
       <a class="hero-btn secondary" href="./upload.html">Contribute a Source</a>
       <a class="hero-btn secondary" href="./stats.html">📊 Statistics</a>
     </div>

--- a/tests/test_evidence_publication_review.py
+++ b/tests/test_evidence_publication_review.py
@@ -1,0 +1,123 @@
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from rdflib import Graph
+
+from scripts.evidence_model import canonical_bytes
+from scripts.evidence_publish import (
+    discovery_projection,
+    graph_to_dataset,
+    publication_graph,
+    publish,
+    tei_standoff,
+)
+from scripts.evidence_review import append_review, make_review, review_state
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "fixtures" / "evidence-first" / "representative.json"
+
+
+def fixture():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_jsonld_and_turtle_round_trip_without_semantic_loss():
+    original = fixture()
+    graph = publication_graph(original)
+    for format_name in ("json-ld", "turtle"):
+        serialized = graph.serialize(format=format_name)
+        restored_graph = Graph().parse(data=serialized, format=format_name)
+        restored = graph_to_dataset(restored_graph)
+        assert canonical_bytes(restored) == canonical_bytes({
+            "schema_version": original["schema_version"],
+            "objects": sorted(original["objects"], key=lambda obj: obj["id"]),
+        })
+
+
+def test_profiles_publish_all_expected_outputs(tmp_path):
+    paths = publish(fixture(), tmp_path)
+    assert set(paths) == {"canonical", "jsonld", "turtle", "discovery", "tei"}
+    assert all(path.exists() and path.stat().st_size for path in paths.values())
+
+
+def test_schema_org_is_explicitly_lossy_discovery_projection():
+    projection = discovery_projection(fixture())
+    assert projection["@context"] == "https://schema.org"
+    assert "Lossy discovery projection" in projection["description"]
+    assert all(item["@id"].startswith("https://outremer.example/id/") for item in projection["hasPart"])
+
+
+def test_tei_links_mentions_without_embedding_graph():
+    xml = tei_standoff(fixture())
+    root = ET.fromstring(xml)
+    spans = root.findall(".//{http://www.tei-c.org/ns/1.0}span")
+    assert {span.text for span in spans} == {"Baldwin", "the pilgrims"}
+    baldwin = next(span for span in spans if span.text == "Baldwin")
+    assert baldwin.attrib["ref"].endswith("/person/baldwin-i")
+    assert "canonicalJson" not in xml
+
+
+def test_reviews_are_append_only_pseudonymous_and_commentable(tmp_path):
+    review = make_review(
+        target_id="outremer:assertion:participation-1",
+        target_type="assertion",
+        action="flag",
+        reviewer="private-user-id",
+        comment="Contradicts the second passage.",
+        timestamp="2026-07-26T10:00:00Z",
+    )
+    path = tmp_path / "reviews.jsonl"
+    append_review(path, review)
+    assert "private-user-id" not in path.read_text(encoding="utf-8")
+    assert review["reviewer"].startswith("reviewer-")
+    assert review["comment"]
+
+
+def test_concurrent_reviewer_disagreement_remains_visible():
+    target = "outremer:identity_hypothesis:baldwin"
+    accept = make_review(
+        target_id=target, target_type="identity_hypothesis", action="accept",
+        reviewer="a", comment="", timestamp="2026-07-26T10:00:00Z",
+    )
+    reject = make_review(
+        target_id=target, target_type="identity_hypothesis", action="reject",
+        reviewer="b", comment="Chronology", timestamp="2026-07-26T10:01:00Z",
+    )
+    state = review_state([accept, reject], target)
+    assert state["conflict"] is True
+    assert len(state["active"]) == 2
+
+
+def test_supersede_preserves_prior_review_history():
+    target = "outremer:assertion:participation-1"
+    first = make_review(
+        target_id=target, target_type="assertion", action="accept",
+        reviewer="a", comment="", timestamp="2026-07-26T10:00:00Z",
+    )
+    replacement = make_review(
+        target_id=target, target_type="assertion", action="supersede",
+        reviewer="a", comment="New evidence", supersedes=first["id"],
+        timestamp="2026-07-26T11:00:00Z",
+    )
+    state = review_state([first, replacement], target)
+    assert len(state["history"]) == 2
+    assert state["active"] == [replacement]
+
+
+def test_review_ui_exposes_all_required_actions():
+    html = (ROOT / "site" / "evidence-review.html").read_text(encoding="utf-8")
+    script = (ROOT / "site" / "evidence-review.js").read_text(encoding="utf-8")
+    assert "identity_hypothesis" in script and "assertion" in script
+    for action in ("accept", "reject", "flag", "supersede"):
+        assert action in script
+    assert "comment" in script and "conflict" in script
+    assert "evidence-review.js" in html
+
+
+def test_existing_decisions_file_is_not_a_publication_or_review_target():
+    sources = (
+        (ROOT / "scripts" / "evidence_publish.py").read_text(encoding="utf-8")
+        + (ROOT / "scripts" / "evidence_review.py").read_text(encoding="utf-8")
+    )
+    assert "data/decisions.json" not in sources


### PR DESCRIPTION
Closes #51.

## What changed

- Added versioned canonical JSON, lossless JSON-LD, and Turtle publication profiles with stable Outremer URIs.
- Preserved sources, passages, verbatim mentions, assertions, uncertainty, temporal bounds, identity hypotheses, rejected candidates, and full decision history through RDF round-trips.
- Reserved `owl:sameAs` for explicit accepted scholarly decisions; imported IDs and scores cannot trigger it.
- Added a clearly labelled lossy schema.org discovery projection.
- Added TEI stand-off annotations linking mentions to accepted Outremer identities.
- Added append-only review decisions for assertions and identity hypotheses: accept, reject, flag, comment, and supersede.
- Kept concurrent reviewer disagreement visible and pseudonymized reviewer identifiers.
- Added and linked the static evidence-review interface.
- Left `data/decisions.json` entirely outside the tooling.

## Verification

- 111 tests passed
- JSON-LD and Turtle representative round-trips are byte-equivalent at canonical-object level
- SHACL valid/broken fixtures remain covered in CI
- All five publication profiles generated successfully
- Offline agreement remains 0.9155
- Ruff and `git diff --check`: clean
