### PR TITLE
M13.1: emit validated evidence-first pipeline records

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,6 +13,7 @@ on:
       - "data/decisions.json"
       - "data/wikidata_matches.json"
       - "data/entity_feedback.json"
+      - "data/evidence/**"
       - "requirements.lock.txt"
   workflow_dispatch:
   schedule:
@@ -80,7 +81,7 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add site/index.json site/data site/bib bib data/entity_feedback.json
+          git add site/index.json site/data site/bib bib data/entity_feedback.json data/evidence
           git add data/staging/eval_history.jsonl 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No changes to commit."

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ python scripts/run_pipeline.py --help
 
 Output: `site/data/*.json`, `site/bib/*.bib`, `bib/*.bib`.
 
+Every processed document also produces a canonical evidence-first artifact at
+`data/evidence/<document-id>.evidence.json`. These records separate immutable
+source snapshots and passages from extracted mentions, assertions, identity
+hypotheses, and generation provenance. They are validated against the
+evidence-first JSON Schema and SHACL shapes before being published. Invalid
+canonical output fails the document run; the existing `site/data` JSON remains
+available as a temporary compatibility format.
+
 ## Tests
 
 ```bash

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -28,3 +28,4 @@ typing_extensions==4.16.0
 zipp==4.1.0
 rdflib==7.6.0
 pyshacl==0.31.0
+jsonschema==4.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ python-dotenv>=1.0  # load .env.gpustack for GPUStack config
 # Kept in requirements.lock.txt so the nightly pipeline retains the fallback.
 rdflib==7.6.0
 pyshacl==0.31.0
+jsonschema==4.25.1

--- a/scripts/evidence_pipeline.py
+++ b/scripts/evidence_pipeline.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Build and validate evidence-first artifacts from production pipeline output."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from evidence_model import SCHEMA_VERSION, canonical_bytes, stable_id, validate_dataset
+from evidence_semantics import dataset_to_graph, validate_graph
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schema" / "evidence-first-v1.schema.json"
+ADAPTER_VERSION = "pipeline-evidence-v1"
+
+
+class EvidencePipelineError(ValueError):
+    """Raised when production output cannot satisfy the canonical contract."""
+
+
+def _timestamp(path: Path) -> str:
+    """Stable snapshot timestamp for an unchanged local source file."""
+    return datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
+
+
+def _identity(
+    identity_id: str,
+    label: str,
+    *,
+    group: bool = False,
+    native_id: str | None = None,
+) -> dict[str, Any]:
+    obj: dict[str, Any] = {
+        "id": identity_id,
+        "type": "group" if group else "person",
+        "version": 1,
+        "preferred_label": label,
+    }
+    if native_id:
+        namespace, _, value = native_id.partition(":")
+        obj["source_native_ids"] = {namespace.lower(): value or native_id}
+    return obj
+
+
+def build_evidence_dataset(
+    *,
+    in_path: Path,
+    doc_id: str,
+    text_sha256: str,
+    metadata: dict[str, Any],
+    persons: list[dict[str, Any]],
+    links: list[dict[str, Any]],
+    extraction_engine: dict[str, Any],
+    language: str | None,
+) -> dict[str, Any]:
+    """Map one legacy pipeline document into the evidence-first v1 contract."""
+    source_key = in_path.as_posix()
+    work_id = stable_id("source_work", source_key)
+    manifestation_id = stable_id("manifestation", source_key, in_path.suffix.lower())
+    snapshot_id = stable_id("snapshot", source_key, text_sha256)
+    activity_id = stable_id(
+        "activity",
+        doc_id,
+        str(extraction_engine.get("provider") or "unknown"),
+        str(extraction_engine.get("model") or "unknown"),
+    )
+    captured_at = _timestamp(in_path)
+    title = str(metadata.get("title") or in_path.stem)
+    citation_bits = [
+        str(metadata.get(key)).strip()
+        for key in ("author", "title", "year")
+        if metadata.get(key)
+    ]
+
+    objects: list[dict[str, Any]] = [
+        {"id": work_id, "type": "source_work", "version": 1, "title": title},
+        {
+            "id": manifestation_id,
+            "type": "manifestation",
+            "version": 1,
+            "work_id": work_id,
+            "citation": ", ".join(citation_bits) or in_path.name,
+        },
+        {
+            "id": snapshot_id,
+            "type": "snapshot",
+            "version": 1,
+            "manifestation_id": manifestation_id,
+            "checksum": text_sha256,
+            "retrieved_at": captured_at,
+            "source_locator": source_key,
+            "ingested_at": captured_at,
+        },
+        {
+            "id": activity_id,
+            "type": "activity",
+            "version": 1,
+            "activity_kind": "extraction",
+            "agent": str(extraction_engine.get("provider") or "unknown"),
+            "started_at": captured_at,
+            "adapter_version": (
+                f"{ADAPTER_VERSION}:{extraction_engine.get('model')}"
+                if extraction_engine.get("model")
+                else ADAPTER_VERSION
+            ),
+        },
+    ]
+    links_by_person = {str(item.get("person")): item for item in links}
+    known_ids = {obj["id"] for obj in objects}
+
+    def add(obj: dict[str, Any]) -> None:
+        if obj["id"] not in known_ids:
+            objects.append(obj)
+            known_ids.add(obj["id"])
+
+    for position, person in enumerate(persons):
+        verbatim = str(person.get("raw_mention") or person.get("name") or "").strip()
+        if not verbatim:
+            continue
+        group = bool(person.get("group"))
+        offset = int(person.get("source_offset") or 0)
+        context = str(person.get("context") or verbatim)
+        passage_id = stable_id("passage", snapshot_id, str(offset), context)
+        mention_id = stable_id("mention", passage_id, verbatim, str(position))
+        provisional_id = stable_id(
+            "group" if group else "person", doc_id, "extracted", verbatim, str(position)
+        )
+        assertion_id = stable_id("assertion", mention_id, "extracted-mention")
+        confidence = max(0.0, min(1.0, float(person.get("confidence") or 0.0)))
+
+        add(
+            {
+                "id": passage_id,
+                "type": "passage",
+                "version": 1,
+                "snapshot_id": snapshot_id,
+                "locator": f"character offset {offset}",
+                "text": context,
+            }
+        )
+        add(
+            {
+                "id": mention_id,
+                "type": "mention",
+                "version": 1,
+                "passage_id": passage_id,
+                "verbatim": verbatim,
+                "language": language or metadata.get("language"),
+                "script": None,
+                "mention_kind": "group" if group else "person",
+            }
+        )
+        add(_identity(provisional_id, str(person.get("name") or verbatim), group=group))
+        add(
+            {
+                "id": assertion_id,
+                "type": "assertion",
+                "version": 1,
+                "passage_ids": [passage_id],
+                "subject_id": provisional_id,
+                "predicate": "extracted_mention",
+                "object": verbatim,
+                "participants": [{"role": "mention_subject", "identity_id": provisional_id}],
+                "semantics": {
+                    "source_certainty": "unknown",
+                    "polarity": "affirmed",
+                    "inference": "extracted",
+                    "source_reliability": "unassessed",
+                    "review_status": "unreviewed",
+                    "extractor_confidence": confidence,
+                },
+                "provenance": {
+                    "snapshot_id": snapshot_id,
+                    "generation_activity_id": activity_id,
+                },
+            }
+        )
+
+        link = links_by_person.get(str(person.get("name"))) or {}
+        candidate_rows: list[dict[str, Any]] = []
+        for candidate in link.get("candidates") or []:
+            native_id = str(candidate.get("outremer_id") or "")
+            label = str(candidate.get("outremer_name") or native_id).strip()
+            if not native_id or not label:
+                continue
+            candidate_group = str(candidate.get("type") or "person") == "group"
+            candidate_id = stable_id(
+                "group" if candidate_group else "person", "authority", native_id
+            )
+            add(
+                _identity(
+                    candidate_id,
+                    label,
+                    group=candidate_group,
+                    native_id=native_id,
+                )
+            )
+            candidate_rows.append(
+                {
+                    "identity_id": candidate_id,
+                    "score": max(0.0, min(1.0, float(candidate.get("score") or 0.0))),
+                    "features": {
+                        "match_type": candidate.get("match_type"),
+                        "evidence": candidate.get("evidence"),
+                    },
+                }
+            )
+        if candidate_rows:
+            add(
+                {
+                    "id": stable_id("identity_hypothesis", mention_id, "authority-linker"),
+                    "type": "identity_hypothesis",
+                    "version": 1,
+                    "mention_id": mention_id,
+                    "candidates": candidate_rows,
+                }
+            )
+
+    return {"schema_version": SCHEMA_VERSION, "objects": objects}
+
+
+def validate_evidence_dataset(dataset: dict[str, Any]) -> None:
+    """Apply operational, JSON Schema, and SHACL validation."""
+    errors = validate_dataset(dataset)
+    if errors:
+        raise EvidencePipelineError("; ".join(errors))
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema_errors = sorted(
+        Draft202012Validator(schema).iter_errors(dataset),
+        key=lambda error: list(error.absolute_path),
+    )
+    if schema_errors:
+        messages = [
+            f"{'/'.join(map(str, error.absolute_path)) or '<root>'}: {error.message}"
+            for error in schema_errors
+        ]
+        raise EvidencePipelineError("JSON Schema: " + "; ".join(messages))
+
+    conforms, report = validate_graph(dataset_to_graph(dataset))
+    if not conforms:
+        raise EvidencePipelineError("SHACL validation failed: " + report)
+
+
+def write_evidence_dataset(dataset: dict[str, Any], output_path: Path) -> Path:
+    """Validate before atomically publishing a canonical JSON artifact."""
+    validate_evidence_dataset(dataset)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output_path.with_suffix(output_path.suffix + ".tmp")
+    temporary.write_bytes(canonical_bytes(dataset))
+    temporary.replace(output_path)
+    return output_path

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -27,6 +27,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from evidence_pipeline import build_evidence_dataset, write_evidence_dataset
 from extract_persons import extract_persons_and_metadata
 from linker import build_authority_lookup, link_voyagers_to_outremer, normalise
 from llm_client import generate as _llm_generate
@@ -400,7 +401,8 @@ def process_file(
     use_llm_metadata: bool,
     language: str | None = None,
     entity_feedback_path: Path | None = None,
-) -> tuple[Path, Path, Path]:
+    evidence_dir: Path | None = None,
+) -> tuple[Path, Path, Path, Path | None, dict[str, Any]]:
     logger.info("Processing %s …", in_path.name)
     text = read_input(in_path)
 
@@ -443,6 +445,21 @@ def process_file(
     json_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     bib_path_repo.write_text(bibtex, encoding="utf-8")
     bib_path_site.write_text(bibtex, encoding="utf-8")
+    evidence_path = None
+    if evidence_dir is not None:
+        evidence = build_evidence_dataset(
+            in_path=in_path,
+            doc_id=doc_id,
+            text_sha256=payload["text_sha256"],
+            metadata=metadata,
+            persons=persons,
+            links=links,
+            extraction_engine=payload["extraction_engine"],
+            language=language,
+        )
+        evidence_path = write_evidence_dataset(
+            evidence, evidence_dir / f"{doc_id}.evidence.json"
+        )
 
     logger.info(
         "  → %d persons, %d links (%d high / %d medium / %d low / %d no_match)",
@@ -457,7 +474,7 @@ def process_file(
         "persons": len(persons),
         "noise": (result.get("quality") or {}).get("noise") or {},
     }
-    return json_path, bib_path_repo, bib_path_site, doc_stats
+    return json_path, bib_path_repo, bib_path_site, evidence_path, doc_stats
 
 
 def build_site_index(site_data_dir: Path, site_dir: Path) -> None:
@@ -481,6 +498,11 @@ def main() -> int:
     ap.add_argument("--file", action="append", dest="files", metavar="FILE", help="Process specific file(s) only (can be repeated)")
     ap.add_argument("--site-dir", default="site", help="Static site folder")
     ap.add_argument("--bib-dir", default="bib", help="Repo-level BibTeX output folder")
+    ap.add_argument(
+        "--evidence-dir",
+        default="data/evidence",
+        help="Validated evidence-first JSON output folder",
+    )
     ap.add_argument("--outremer-index", default="scripts/outremer_index.json")
     ap.add_argument(
         "--require-outremer-index",
@@ -522,6 +544,7 @@ def main() -> int:
     in_dir = Path(args.input_dir)
     site_dir = Path(args.site_dir)
     bib_dir = Path(args.bib_dir)
+    evidence_dir = Path(args.evidence_dir)
     outremer_path = Path(args.outremer_index)
     entity_feedback_path = Path(args.entity_feedback_path) if args.entity_feedback_path else None
     review_decisions_path = Path(args.review_decisions_path) if args.review_decisions_path else None
@@ -529,7 +552,7 @@ def main() -> int:
     site_data_dir = site_dir / "data"
     site_bib_dir = site_dir / "bib"
 
-    for d in (site_dir, site_data_dir, site_bib_dir, bib_dir):
+    for d in (site_dir, site_data_dir, site_bib_dir, bib_dir, evidence_dir):
         d.mkdir(parents=True, exist_ok=True)
 
     try:
@@ -597,7 +620,7 @@ def main() -> int:
     else:
         for p in inputs:
             try:
-                json_path, bib_repo, bib_site, doc_stats = process_file(
+                json_path, bib_repo, bib_site, evidence_path, doc_stats = process_file(
                     p,
                     site_data_dir=site_data_dir,
                     bib_dir=bib_dir,
@@ -606,10 +629,12 @@ def main() -> int:
                     use_llm_metadata=args.llm_metadata,
                     language=args.language,
                     entity_feedback_path=entity_feedback_path,
+                    evidence_dir=evidence_dir,
                 )
                 print(f"Wrote {json_path}")
                 print(f"Wrote {bib_repo}")
                 print(f"Wrote {bib_site}")
+                print(f"Wrote {evidence_path}")
                 total_persons += doc_stats["persons"]
                 for k in noise_agg:
                     noise_agg[k] += (doc_stats.get("noise") or {}).get(k, 0)

--- a/tests/test_evidence_pipeline.py
+++ b/tests/test_evidence_pipeline.py
@@ -1,0 +1,91 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.evidence_pipeline import (
+    EvidencePipelineError,
+    build_evidence_dataset,
+    validate_evidence_dataset,
+    write_evidence_dataset,
+)
+
+
+def source(tmp_path: Path) -> Path:
+    path = tmp_path / "chronicle.txt"
+    path.write_text("Baldwin went to Jerusalem.", encoding="utf-8")
+    os.utime(path, (1_700_000_000, 1_700_000_000))
+    return path
+
+
+def dataset(tmp_path: Path):
+    path = source(tmp_path)
+    return build_evidence_dataset(
+        in_path=path,
+        doc_id="chronicle-a1b2c3",
+        text_sha256="a" * 64,
+        metadata={"title": "A Chronicle", "author": "Anonymous", "language": "en"},
+        persons=[
+            {
+                "name": "Baldwin",
+                "raw_mention": "Baldwin",
+                "context": "Baldwin went to Jerusalem.",
+                "source_offset": 0,
+                "confidence": 0.87,
+                "group": False,
+            }
+        ],
+        links=[
+            {
+                "person": "Baldwin",
+                "candidates": [
+                    {
+                        "outremer_id": "AUTH:CR1",
+                        "outremer_name": "Baldwin I of Jerusalem",
+                        "type": "person",
+                        "score": 0.92,
+                        "match_type": "variant",
+                        "evidence": "preferred label",
+                    }
+                ],
+            }
+        ],
+        extraction_engine={"provider": "gpustack", "model": "qwen"},
+        language="en",
+    )
+
+
+def test_builds_deterministic_valid_evidence_dataset(tmp_path):
+    first = dataset(tmp_path)
+    second = dataset(tmp_path)
+    assert first == second
+    validate_evidence_dataset(first)
+    types = {obj["type"] for obj in first["objects"]}
+    assert {
+        "source_work",
+        "manifestation",
+        "snapshot",
+        "passage",
+        "mention",
+        "assertion",
+        "person",
+        "identity_hypothesis",
+        "activity",
+    } <= types
+
+
+def test_writer_publishes_canonical_json_only_after_validation(tmp_path):
+    data = dataset(tmp_path)
+    output = tmp_path / "evidence" / "chronicle.evidence.json"
+    write_evidence_dataset(data, output)
+    assert json.loads(output.read_text(encoding="utf-8")) == data
+    assert not output.with_suffix(".json.tmp").exists()
+
+
+def test_validation_rejects_assertion_without_passage(tmp_path):
+    data = dataset(tmp_path)
+    assertion = next(obj for obj in data["objects"] if obj["type"] == "assertion")
+    assertion["passage_ids"] = []
+    with pytest.raises(EvidencePipelineError, match="evidence passage"):
+        validate_evidence_dataset(data)


### PR DESCRIPTION
## Summary

- emit one deterministic evidence-first JSON artifact per processed document
- model source work, manifestation, immutable snapshot, passages, mentions,
  extracted assertions, provisional identities, authority candidates, identity
  hypotheses, and extraction activity provenance
- validate every artifact with operational contract checks, JSON Schema, and
  SHACL before an atomic write
- retain the existing `site/data` output as a compatibility format
- commit generated `data/evidence` artifacts from the nightly pipeline
- document the output and add offline generation/failure tests

## Validation

- `python3 -m pytest tests/ -q --import-mode=importlib` — 114 passed
- `ruff check scripts/ tests/` — passed
- production-shaped validation — 5 existing documents converted and validated

Closes #63.
