### PR TITLE
M19.3: record pre-enrichment authority baseline

### DIFF
--- a/evaluation/authority_enrichment_report.py
+++ b/evaluation/authority_enrichment_report.py
@@ -1,0 +1,103 @@
+"""Reproducible before/after report for Epic 19 authority enrichment."""
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+from evaluation._pipeline import load_authority_lookup, relink
+from evaluation.diagnose import diagnose_document
+from evaluation.metrics import (
+    DEFAULT_FUZZY_THRESHOLD,
+    _fuzzy_equal,
+    linking_agreement,
+    split_pairs_by_system,
+)
+from evaluation.sweep import sweep
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _top_id(link: dict) -> str | None:
+    top = link.get("top_candidate") or {}
+    return top.get("outremer_id") or top.get("authority_id")
+
+
+def _score_bin(score: float) -> str:
+    lower = int(score * 20) / 20
+    if lower >= 1:
+        return "[1.00]"
+    return f"[{lower:.2f},{lower + 0.05:.2f})"
+
+
+def build_report(fixtures_dir: Path = FIXTURES) -> dict:
+    lookup = load_authority_lookup()
+    totals = Counter()
+    causes = Counter()
+    correct_scores: list[float] = []
+
+    for path in sorted(fixtures_dir.glob("*.json")):
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+        predictions = fixture.get("predictions") or {}
+        persons = predictions.get("persons") or []
+        accepted, _ = split_pairs_by_system(
+            [tuple(item) for item in fixture.get("accepted", [])]
+        )
+        rejected, _ = split_pairs_by_system(
+            [tuple(item) for item in fixture.get("rejected", [])]
+        )
+        if not persons or not (accepted or rejected):
+            continue
+
+        links = relink(persons, lookup)
+        metrics = linking_agreement(links, accepted, rejected)
+        totals.update(metrics)
+        rows = diagnose_document(fixture["doc_id"], accepted, persons, links)
+        causes.update(row["cause"] for row in rows)
+
+        for mention, accepted_id in accepted:
+            for link in links:
+                if (
+                    _fuzzy_equal(link.get("person", ""), mention, DEFAULT_FUZZY_THRESHOLD)
+                    and _top_id(link) == accepted_id
+                ):
+                    correct_scores.append(float(link.get("confidence") or 0))
+                    break
+
+    reviewed = totals["reviewed_pairs"]
+    good = totals["accept_hit"] + totals["reject_avoided"]
+    bins = Counter(_score_bin(score) for score in correct_scores)
+    return {
+        "authority": {
+            "agreement": round(good / reviewed, 4) if reviewed else 0.0,
+            "reviewed_pairs": reviewed,
+            "accept_hit": totals["accept_hit"],
+            "accept_miss": totals["accept_miss"],
+            "reject_hit": totals["reject_hit"],
+            "reject_avoided": totals["reject_avoided"],
+        },
+        "accepted_pair_diagnosis": dict(sorted(causes.items())),
+        "correct_match_score_distribution": dict(sorted(bins.items())),
+        "candidate_floor_sweep": sweep(
+            [0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85], fixtures_dir
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixtures", type=Path, default=FIXTURES)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    report = build_report(args.fixtures)
+    rendered = json.dumps(report, indent=2, ensure_ascii=False)
+    print(rendered)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evaluation/baselines/epic19-pre-enrichment.json
+++ b/evaluation/baselines/epic19-pre-enrichment.json
@@ -1,0 +1,82 @@
+{
+  "authority": {
+    "agreement": 0.8909,
+    "reviewed_pairs": 55,
+    "accept_hit": 4,
+    "accept_miss": 3,
+    "reject_hit": 3,
+    "reject_avoided": 45
+  },
+  "accepted_pair_diagnosis": {
+    "HIT": 4,
+    "not_extracted": 3
+  },
+  "correct_match_score_distribution": {
+    "[0.60,0.65)": 4
+  },
+  "candidate_floor_sweep": [
+    {
+      "floor": 0.55,
+      "agreement": 0.8909,
+      "reviewed_pairs": 55,
+      "accept_hit": 4,
+      "accept_miss": 3,
+      "reject_hit": 3,
+      "reject_avoided": 45
+    },
+    {
+      "floor": 0.6,
+      "agreement": 0.8909,
+      "reviewed_pairs": 55,
+      "accept_hit": 4,
+      "accept_miss": 3,
+      "reject_hit": 3,
+      "reject_avoided": 45
+    },
+    {
+      "floor": 0.65,
+      "agreement": 0.8364,
+      "reviewed_pairs": 55,
+      "accept_hit": 0,
+      "accept_miss": 7,
+      "reject_hit": 2,
+      "reject_avoided": 46
+    },
+    {
+      "floor": 0.7,
+      "agreement": 0.8545,
+      "reviewed_pairs": 55,
+      "accept_hit": 0,
+      "accept_miss": 7,
+      "reject_hit": 1,
+      "reject_avoided": 47
+    },
+    {
+      "floor": 0.75,
+      "agreement": 0.8545,
+      "reviewed_pairs": 55,
+      "accept_hit": 0,
+      "accept_miss": 7,
+      "reject_hit": 1,
+      "reject_avoided": 47
+    },
+    {
+      "floor": 0.8,
+      "agreement": 0.8545,
+      "reviewed_pairs": 55,
+      "accept_hit": 0,
+      "accept_miss": 7,
+      "reject_hit": 1,
+      "reject_avoided": 47
+    },
+    {
+      "floor": 0.85,
+      "agreement": 0.8545,
+      "reviewed_pairs": 55,
+      "accept_hit": 0,
+      "accept_miss": 7,
+      "reject_hit": 1,
+      "reject_avoided": 47
+    }
+  ]
+}

--- a/tests/test_authority_enrichment_report.py
+++ b/tests/test_authority_enrichment_report.py
@@ -1,0 +1,20 @@
+from evaluation.authority_enrichment_report import build_report
+
+
+def test_epic19_report_contains_comparable_metrics():
+    report = build_report()
+    authority = report["authority"]
+    assert authority["reviewed_pairs"] == 55
+    assert authority["accept_hit"] + authority["accept_miss"] > 0
+    assert authority["reject_hit"] + authority["reject_avoided"] > 0
+    assert report["accepted_pair_diagnosis"]
+    assert report["correct_match_score_distribution"]
+    assert [row["floor"] for row in report["candidate_floor_sweep"]] == [
+        0.55,
+        0.60,
+        0.65,
+        0.70,
+        0.75,
+        0.80,
+        0.85,
+    ]


### PR DESCRIPTION
## Summary

- add a reproducible Epic 19 authority-enrichment report
- record the pre-enrichment `--relink` baseline
- include authority agreement and accept/reject hit/miss counts
- classify accepted-pair failures
- record the score distribution of correct matches
- sweep the candidate floor from 0.55 through 0.85

## Baseline

- authority agreement: 0.8909 over 55 reviewed pairs
- accept hit/miss: 4 / 3
- reject hit/avoided: 3 / 45
- all four correct matches score in `[0.60,0.65)`
- all three accepted misses are currently `not_extracted`, not linker failures
- raising the candidate floor to 0.65 loses all four correct authority matches

## Validation

- 115 tests passed
- Ruff passed

This is the pre-enrichment half of #93. The issue should remain open until
M19.1/M19.2 land and the same report records the after-state.
