### PR TITLE
M19.0: audit corrupt authority adjudication gold

### DIFF
--- a/evaluation/authority_enrichment_report.py
+++ b/evaluation/authority_enrichment_report.py
@@ -6,7 +6,7 @@ import json
 from collections import Counter
 from pathlib import Path
 
-from evaluation._pipeline import load_authority_lookup, relink
+from evaluation._pipeline import REPO_ROOT, load_authority_lookup, relink
 from evaluation.diagnose import diagnose_document
 from evaluation.metrics import (
     DEFAULT_FUZZY_THRESHOLD,
@@ -15,6 +15,7 @@ from evaluation.metrics import (
     split_pairs_by_system,
 )
 from evaluation.sweep import sweep
+from scripts.linker import normalise
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
@@ -33,9 +34,16 @@ def _score_bin(score: float) -> str:
 
 def build_report(fixtures_dir: Path = FIXTURES) -> dict:
     lookup = load_authority_lookup()
+    authority_source = json.loads(
+        (REPO_ROOT / "scripts" / "outremer_index.json").read_text(encoding="utf-8")
+    )
+    authority = {
+        item["authority_id"]: item for item in authority_source.get("persons", [])
+    }
     totals = Counter()
     causes = Counter()
     correct_scores: list[float] = []
+    accepted_pair_audit: list[dict] = []
 
     for path in sorted(fixtures_dir.glob("*.json")):
         fixture = json.loads(path.read_text(encoding="utf-8"))
@@ -47,6 +55,26 @@ def build_report(fixtures_dir: Path = FIXTURES) -> dict:
         rejected, _ = split_pairs_by_system(
             [tuple(item) for item in fixture.get("rejected", [])]
         )
+        for mention, authority_id in accepted:
+            record = authority.get(authority_id)
+            attested_names = (
+                [record.get("preferred_label", ""), *(record.get("variants") or [])]
+                if record
+                else []
+            )
+            exact_attestation = any(
+                normalise(name) == normalise(mention) for name in attested_names if name
+            )
+            accepted_pair_audit.append(
+                {
+                    "document": fixture["doc_id"],
+                    "mention": mention,
+                    "authority_id": authority_id,
+                    "authority_label": record.get("preferred_label") if record else None,
+                    "exact_attested_variant": exact_attestation,
+                    "status": "attested" if exact_attestation else "needs_scholarly_review",
+                }
+            )
         if not persons or not (accepted or rejected):
             continue
 
@@ -78,6 +106,9 @@ def build_report(fixtures_dir: Path = FIXTURES) -> dict:
             "reject_avoided": totals["reject_avoided"],
         },
         "accepted_pair_diagnosis": dict(sorted(causes.items())),
+        "accepted_authority_pair_audit": sorted(
+            accepted_pair_audit, key=lambda row: (row["document"], row["mention"])
+        ),
         "correct_match_score_distribution": dict(sorted(bins.items())),
         "candidate_floor_sweep": sweep(
             [0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85], fixtures_dir

--- a/evaluation/baselines/epic19-pre-enrichment.json
+++ b/evaluation/baselines/epic19-pre-enrichment.json
@@ -11,6 +11,64 @@
     "HIT": 4,
     "not_extracted": 3
   },
+  "accepted_authority_pair_audit": [
+    {
+      "document": "rileysmith-motivesearliestcrusaders-1983-92cc17aaccd3",
+      "mention": "Albert of Aachen",
+      "authority_id": "AUTH:CR124",
+      "authority_label": "Henry of Limal",
+      "exact_attested_variant": false,
+      "status": "needs_scholarly_review"
+    },
+    {
+      "document": "rileysmith-motivesearliestcrusaders-1983-92cc17aaccd3",
+      "mention": "Ekkehard",
+      "authority_id": "AUTH:CR14",
+      "authority_label": "Erard I of Brienne",
+      "exact_attested_variant": false,
+      "status": "needs_scholarly_review"
+    },
+    {
+      "document": "rileysmith-motivesearliestcrusaders-1983-92cc17aaccd3",
+      "mention": "Ekkehard of Aura",
+      "authority_id": "AUTH:CR87",
+      "authority_label": "Ermengarde of Anjou",
+      "exact_attested_variant": false,
+      "status": "needs_scholarly_review"
+    },
+    {
+      "document": "rileysmith-motivesearliestcrusaders-1983-92cc17aaccd3",
+      "mention": "Fulcher of Chartres",
+      "authority_id": "AUTH:CR33",
+      "authority_label": "Charles of Denmark",
+      "exact_attested_variant": false,
+      "status": "needs_scholarly_review"
+    },
+    {
+      "document": "rileysmith-motivesearliestcrusaders-1983-92cc17aaccd3",
+      "mention": "Kingdom of Hungary",
+      "authority_id": "AUTH:CR124",
+      "authority_label": "Henry of Limal",
+      "exact_attested_variant": false,
+      "status": "needs_scholarly_review"
+    },
+    {
+      "document": "rileysmith-motivesearliestcrusaders-1983-92cc17aaccd3",
+      "mention": "Peter",
+      "authority_id": "AUTH:CR53",
+      "authority_label": "Peter of Langres",
+      "exact_attested_variant": true,
+      "status": "attested"
+    },
+    {
+      "document": "rileysmith-motivesearliestcrusaders-1983-92cc17aaccd3",
+      "mention": "Tancred",
+      "authority_id": "AUTH:CR86",
+      "authority_label": "Constance of Toulouse",
+      "exact_attested_variant": false,
+      "status": "needs_scholarly_review"
+    }
+  ],
   "correct_match_score_distribution": {
     "[0.60,0.65)": 4
   },

--- a/tests/test_authority_enrichment_report.py
+++ b/tests/test_authority_enrichment_report.py
@@ -9,6 +9,15 @@ def test_epic19_report_contains_comparable_metrics():
     assert authority["reject_hit"] + authority["reject_avoided"] > 0
     assert report["accepted_pair_diagnosis"]
     assert report["correct_match_score_distribution"]
+    audit = report["accepted_authority_pair_audit"]
+    assert len(audit) == 7
+    suspicious = {
+        (row["mention"], row["authority_id"], row["authority_label"])
+        for row in audit
+        if row["status"] == "needs_scholarly_review"
+    }
+    assert ("Ekkehard", "AUTH:CR14", "Erard I of Brienne") in suspicious
+    assert ("Fulcher of Chartres", "AUTH:CR33", "Charles of Denmark") in suspicious
     assert [row["floor"] for row in report["candidate_floor_sweep"]] == [
         0.55,
         0.60,


### PR DESCRIPTION
## Summary

- audit every accepted `AUTH:*` adjudication against the current authority
  label and attested variants
- include the semantic audit in the reproducible Epic 19 baseline artifact
- flag accepted pairs without an exact authority attestation for scholarly
  review
- add regression assertions for known wrong-person pairs

## Findings

Six of seven accepted authority pairs require review:

- Albert of Aachen → Henry of Limal
- Ekkehard → Erard I of Brienne
- Ekkehard of Aura → Ermengarde of Anjou
- Fulcher of Chartres → Charles of Denmark
- Kingdom of Hungary → Henry of Limal
- Tancred → Constance of Toulouse

The seventh, `Peter → Peter of Langres`, is textually attested but too generic
to establish identity without context.

This PR is stacked on #96 because the audit is part of its reproducible
baseline report. It does not rewrite historical decisions.

## Validation

- targeted audit test passed
- Ruff passed

Refs #97. Blocks enrichment in #91/#92 until scholarly adjudication is repaired.
