### PR TITLE
M19.2: add sourced authority coverage audit

### DIFF
--- a/data/audits/epic19-benchmark-figures.json
+++ b/data/audits/epic19-benchmark-figures.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "scope": "Named benchmark figures for the First Crusade and its principal narrative traditions",
+  "sources": [
+    {
+      "id": "riley-smith-first-crusaders",
+      "citation": "Jonathan Riley-Smith, The First Crusaders, 1095–1131 (Cambridge, 1997)",
+      "use": "Latin-Christian participant and chronicler coverage benchmark"
+    },
+    {
+      "id": "outremer-corpus",
+      "citation": "Outremer adjudicated source corpus",
+      "use": "Figures explicitly encountered and reviewed in project texts"
+    },
+    {
+      "id": "wikidata-cc0",
+      "citation": "Wikidata entity search, checked 2026-07-30, CC0",
+      "use": "Stable open identifiers only; not sole evidence for historical assertions"
+    }
+  ],
+  "figures": [
+    {"preferred_label": "Godfrey of Bouillon", "tradition": "Latin Christian", "role": "participant", "wikidata": "Q76721", "sources": ["riley-smith-first-crusaders", "outremer-corpus", "wikidata-cc0"]},
+    {"preferred_label": "Urban II", "variants": ["Pope Urban II"], "tradition": "Latin Christian", "role": "pope", "wikidata": "Q30578", "sources": ["riley-smith-first-crusaders", "outremer-corpus", "wikidata-cc0"]},
+    {"preferred_label": "Albert of Aachen", "variants": ["Albert of Aix"], "tradition": "Latin Christian", "role": "chronicler", "wikidata": "Q4323", "sources": ["outremer-corpus", "wikidata-cc0"]},
+    {"preferred_label": "Ekkehard of Aura", "variants": ["Ekkehard"], "tradition": "Latin Christian", "role": "chronicler", "wikidata": "Q66673", "sources": ["outremer-corpus", "wikidata-cc0"]},
+    {"preferred_label": "Fulcher of Chartres", "tradition": "Latin Christian", "role": "chronicler", "wikidata": "Q5630", "sources": ["outremer-corpus", "wikidata-cc0"]},
+    {"preferred_label": "Guibert of Nogent", "tradition": "Latin Christian", "role": "chronicler", "wikidata": "Q4289", "sources": ["outremer-corpus", "wikidata-cc0"]},
+    {"preferred_label": "Orderic Vitalis", "tradition": "Latin Christian", "role": "chronicler", "wikidata": "Q356298", "sources": ["outremer-corpus", "wikidata-cc0"]},
+    {"preferred_label": "William of Tyre", "tradition": "Latin Christian", "role": "chronicler", "wikidata": "Q311822", "sources": ["wikidata-cc0"]},
+    {"preferred_label": "Anna Komnene", "tradition": "Byzantine", "role": "historian", "wikidata": "Q179284", "sources": ["wikidata-cc0"]},
+    {"preferred_label": "Alexios I Komnenos", "tradition": "Byzantine", "role": "ruler", "sources": ["riley-smith-first-crusaders"]},
+    {"preferred_label": "Ibn al-Qalanisi", "tradition": "Arabic-Islamic", "role": "chronicler", "sources": ["riley-smith-first-crusaders"]},
+    {"preferred_label": "Ibn al-Athir", "tradition": "Arabic-Islamic", "role": "chronicler", "sources": ["riley-smith-first-crusaders"]},
+    {"preferred_label": "Usama ibn Munqidh", "tradition": "Arabic-Islamic", "role": "author and participant", "sources": ["riley-smith-first-crusaders"]},
+    {"preferred_label": "Matthew of Edessa", "tradition": "Armenian", "role": "chronicler", "sources": ["riley-smith-first-crusaders"]}
+  ]
+}

--- a/data/audits/epic19-coverage-report.json
+++ b/data/audits/epic19-coverage-report.json
@@ -1,0 +1,200 @@
+{
+  "schema_version": 1,
+  "authority_records": 129,
+  "benchmark_figures": 14,
+  "summary": {
+    "missing": 13,
+    "present": 1
+  },
+  "by_tradition": {
+    "Arabic-Islamic": {
+      "total": 3,
+      "present": 0,
+      "missing": 3
+    },
+    "Armenian": {
+      "total": 1,
+      "present": 0,
+      "missing": 1
+    },
+    "Byzantine": {
+      "total": 2,
+      "present": 0,
+      "missing": 2
+    },
+    "Latin Christian": {
+      "total": 8,
+      "present": 1,
+      "missing": 7
+    }
+  },
+  "figures": [
+    {
+      "preferred_label": "Godfrey of Bouillon",
+      "tradition": "Latin Christian",
+      "role": "participant",
+      "wikidata": "Q76721",
+      "sources": [
+        "riley-smith-first-crusaders",
+        "outremer-corpus",
+        "wikidata-cc0"
+      ],
+      "status": "present",
+      "authority_id": "AUTH:CR184"
+    },
+    {
+      "preferred_label": "Urban II",
+      "variants": [
+        "Pope Urban II"
+      ],
+      "tradition": "Latin Christian",
+      "role": "pope",
+      "wikidata": "Q30578",
+      "sources": [
+        "riley-smith-first-crusaders",
+        "outremer-corpus",
+        "wikidata-cc0"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Albert of Aachen",
+      "variants": [
+        "Albert of Aix"
+      ],
+      "tradition": "Latin Christian",
+      "role": "chronicler",
+      "wikidata": "Q4323",
+      "sources": [
+        "outremer-corpus",
+        "wikidata-cc0"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Ekkehard of Aura",
+      "variants": [
+        "Ekkehard"
+      ],
+      "tradition": "Latin Christian",
+      "role": "chronicler",
+      "wikidata": "Q66673",
+      "sources": [
+        "outremer-corpus",
+        "wikidata-cc0"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Fulcher of Chartres",
+      "tradition": "Latin Christian",
+      "role": "chronicler",
+      "wikidata": "Q5630",
+      "sources": [
+        "outremer-corpus",
+        "wikidata-cc0"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Guibert of Nogent",
+      "tradition": "Latin Christian",
+      "role": "chronicler",
+      "wikidata": "Q4289",
+      "sources": [
+        "outremer-corpus",
+        "wikidata-cc0"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Orderic Vitalis",
+      "tradition": "Latin Christian",
+      "role": "chronicler",
+      "wikidata": "Q356298",
+      "sources": [
+        "outremer-corpus",
+        "wikidata-cc0"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "William of Tyre",
+      "tradition": "Latin Christian",
+      "role": "chronicler",
+      "wikidata": "Q311822",
+      "sources": [
+        "wikidata-cc0"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Anna Komnene",
+      "tradition": "Byzantine",
+      "role": "historian",
+      "wikidata": "Q179284",
+      "sources": [
+        "wikidata-cc0"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Alexios I Komnenos",
+      "tradition": "Byzantine",
+      "role": "ruler",
+      "sources": [
+        "riley-smith-first-crusaders"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Ibn al-Qalanisi",
+      "tradition": "Arabic-Islamic",
+      "role": "chronicler",
+      "sources": [
+        "riley-smith-first-crusaders"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Ibn al-Athir",
+      "tradition": "Arabic-Islamic",
+      "role": "chronicler",
+      "sources": [
+        "riley-smith-first-crusaders"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Usama ibn Munqidh",
+      "tradition": "Arabic-Islamic",
+      "role": "author and participant",
+      "sources": [
+        "riley-smith-first-crusaders"
+      ],
+      "status": "missing",
+      "authority_id": null
+    },
+    {
+      "preferred_label": "Matthew of Edessa",
+      "tradition": "Armenian",
+      "role": "chronicler",
+      "sources": [
+        "riley-smith-first-crusaders"
+      ],
+      "status": "missing",
+      "authority_id": null
+    }
+  ]
+}

--- a/scripts/audit_authority_coverage.py
+++ b/scripts/audit_authority_coverage.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Audit the authority file against a sourced, multilingual benchmark list."""
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+from linker import normalise
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_AUTHORITY = ROOT / "scripts" / "outremer_index.json"
+DEFAULT_BENCHMARK = ROOT / "data" / "audits" / "epic19-benchmark-figures.json"
+DEFAULT_OUTPUT = ROOT / "data" / "audits" / "epic19-coverage-report.json"
+
+
+def audit(authority_path: Path, benchmark_path: Path) -> dict:
+    authority = json.loads(authority_path.read_text(encoding="utf-8"))
+    benchmark = json.loads(benchmark_path.read_text(encoding="utf-8"))
+    names: dict[str, str] = {}
+    for record in authority.get("persons", []):
+        for name in [record.get("preferred_label"), *(record.get("variants") or [])]:
+            if name:
+                names.setdefault(normalise(name), record["authority_id"])
+
+    rows = []
+    for figure in benchmark.get("figures", []):
+        candidate_names = [
+            figure["preferred_label"],
+            *(figure.get("variants") or []),
+        ]
+        matched_id = next(
+            (names[normalise(name)] for name in candidate_names if normalise(name) in names),
+            None,
+        )
+        rows.append(
+            {
+                **figure,
+                "status": "present" if matched_id else "missing",
+                "authority_id": matched_id,
+            }
+        )
+
+    by_tradition = {}
+    for tradition in sorted({row["tradition"] for row in rows}):
+        subset = [row for row in rows if row["tradition"] == tradition]
+        by_tradition[tradition] = {
+            "total": len(subset),
+            "present": sum(row["status"] == "present" for row in subset),
+            "missing": sum(row["status"] == "missing" for row in subset),
+        }
+    statuses = Counter(row["status"] for row in rows)
+    return {
+        "schema_version": 1,
+        "authority_records": len(authority.get("persons", [])),
+        "benchmark_figures": len(rows),
+        "summary": dict(sorted(statuses.items())),
+        "by_tradition": by_tradition,
+        "figures": rows,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--authority", type=Path, default=DEFAULT_AUTHORITY)
+    parser.add_argument("--benchmark", type=Path, default=DEFAULT_BENCHMARK)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args(argv)
+    report = audit(args.authority, args.benchmark)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(
+        f"{report['summary'].get('present', 0)} present; "
+        f"{report['summary'].get('missing', 0)} missing"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_authority_coverage_audit.py
+++ b/tests/test_authority_coverage_audit.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from scripts.audit_authority_coverage import audit
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_coverage_audit_exposes_named_and_tradition_gaps():
+    report = audit(
+        ROOT / "scripts" / "outremer_index.json",
+        ROOT / "data" / "audits" / "epic19-benchmark-figures.json",
+    )
+    assert report["authority_records"] == 129
+    rows = {row["preferred_label"]: row for row in report["figures"]}
+    assert rows["Godfrey of Bouillon"]["status"] == "present"
+    assert rows["Fulcher of Chartres"]["status"] == "missing"
+    assert report["by_tradition"]["Arabic-Islamic"]["missing"] == 3
+    assert report["by_tradition"]["Armenian"]["missing"] == 1


### PR DESCRIPTION
## Summary

- add a sourced benchmark list for named First-Crusade figures and narrative
  traditions
- add a reproducible authority-coverage audit
- report coverage by Latin-Christian, Byzantine, Arabic-Islamic, and Armenian
  traditions
- include stable open identifiers where verified
- add regression coverage for known present and missing figures

## Initial result

- 14 benchmark figures
- 1 present: Godfrey of Bouillon
- 13 missing
- zero coverage for the Arabic-Islamic, Armenian, and Byzantine benchmark
  figures
- missing chroniclers include Albert of Aachen, Ekkehard of Aura, Fulcher of
  Chartres, Guibert of Nogent, Orderic Vitalis, and William of Tyre

This PR establishes the named audit list required by #92. Adding records remains
separate scholarly curation work and must respect #48 and the adjudication
integrity blocker #97.

## Validation

- 115 tests passed
- Ruff passed

Refs #92.
