### PR TITLE
M19.4: attribute every authority name form

### DIFF
--- a/scripts/backfill_authority_provenance.py
+++ b/scripts/backfill_authority_provenance.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Backfill and validate per-name-form provenance in the authority index."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_INDEX = ROOT / "scripts" / "outremer_index.json"
+
+
+def _sources(record: dict) -> list[dict[str, str]]:
+    provenance = record.get("provenance") or {}
+    system = str(provenance.get("source_system") or "").strip()
+    sources = [
+        {"system": system, "locator": str(path)}
+        for path in provenance.get("source_files") or []
+        if system and path
+    ]
+    if not sources and system == "manual":
+        note = str(provenance.get("note") or "")
+        issue = re.search(r"issue\s+#(\d+)", note, flags=re.IGNORECASE)
+        if issue:
+            sources.append({"system": "github-issue", "locator": f"issue:{issue.group(1)}"})
+    return sources
+
+
+def backfill(index: dict) -> dict:
+    for record in index.get("persons", []):
+        sources = _sources(record)
+        if not sources:
+            raise ValueError(f"{record.get('authority_id')}: no attributable source")
+        names = [record.get("preferred_label"), *(record.get("variants") or [])]
+        record["variant_provenance"] = {
+            name: [dict(source) for source in sources] for name in names if name
+        }
+    return index
+
+
+def validate(index: dict) -> list[str]:
+    errors = []
+    for record in index.get("persons", []):
+        provenance = record.get("variant_provenance") or {}
+        names = {record.get("preferred_label"), *(record.get("variants") or [])}
+        names.discard(None)
+        if set(provenance) != names:
+            errors.append(f"{record.get('authority_id')}: name/provenance coverage differs")
+        for name, sources in provenance.items():
+            if not sources or any(
+                not source.get("system") or not source.get("locator") for source in sources
+            ):
+                errors.append(
+                    f"{record.get('authority_id')} {name!r}: incomplete provenance"
+                )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("index", type=Path, nargs="?", default=DEFAULT_INDEX)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+    data = json.loads(args.index.read_text(encoding="utf-8"))
+    if not args.check:
+        backfill(data)
+        args.index.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+    errors = validate(data)
+    if errors:
+        print("\n".join(errors))
+        return 1
+    print(f"{len(data.get('persons', []))} authority records have per-variant provenance")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/outremer_index.json
+++ b/scripts/outremer_index.json
@@ -45,6 +45,56 @@
           "person/item_149.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Conrad III of Germany": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_149.xml"
+          }
+        ],
+        "Conrad": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_149.xml"
+          }
+        ],
+        "Conrad (Germany)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_149.xml"
+          }
+        ],
+        "Conrad 3": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_149.xml"
+          }
+        ],
+        "Conrad 3 of Germany": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_149.xml"
+          }
+        ],
+        "Conrad III": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_149.xml"
+          }
+        ],
+        "Conrad, Germany": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_149.xml"
+          }
+        ],
+        "Germany's Conrad": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_149.xml"
+          }
+        ]
       }
     },
     {
@@ -89,6 +139,56 @@
           "person/item_150.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Fulk V of Anjou": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_150.xml"
+          }
+        ],
+        "Anjou's Fulk": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_150.xml"
+          }
+        ],
+        "Fulk": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_150.xml"
+          }
+        ],
+        "Fulk (Anjou)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_150.xml"
+          }
+        ],
+        "Fulk 5": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_150.xml"
+          }
+        ],
+        "Fulk 5 of Anjou": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_150.xml"
+          }
+        ],
+        "Fulk V": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_150.xml"
+          }
+        ],
+        "Fulk, Anjou": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_150.xml"
+          }
+        ]
       }
     },
     {
@@ -126,6 +226,38 @@
           "person/item_151.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Baldwin of Vern d'Anjou": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_151.xml"
+          }
+        ],
+        "Baldwin": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_151.xml"
+          }
+        ],
+        "Baldwin (Vern d'Anjou)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_151.xml"
+          }
+        ],
+        "Baldwin, Vern d'Anjou": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_151.xml"
+          }
+        ],
+        "Vern d'Anjou's Baldwin": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_151.xml"
+          }
+        ]
       }
     },
     {
@@ -170,6 +302,56 @@
           "person/item_152.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Berlay II of Montreuil": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_152.xml"
+          }
+        ],
+        "Berlay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_152.xml"
+          }
+        ],
+        "Berlay (Montreuil)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_152.xml"
+          }
+        ],
+        "Berlay 2": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_152.xml"
+          }
+        ],
+        "Berlay 2 of Montreuil": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_152.xml"
+          }
+        ],
+        "Berlay II": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_152.xml"
+          }
+        ],
+        "Berlay, Montreuil": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_152.xml"
+          }
+        ],
+        "Montreuil's Berlay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_152.xml"
+          }
+        ]
       }
     },
     {
@@ -214,6 +396,56 @@
           "person/item_153.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Berlay III of Montreuil": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_153.xml"
+          }
+        ],
+        "Berlay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_153.xml"
+          }
+        ],
+        "Berlay (Montreuil)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_153.xml"
+          }
+        ],
+        "Berlay 3": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_153.xml"
+          }
+        ],
+        "Berlay 3 of Montreuil": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_153.xml"
+          }
+        ],
+        "Berlay III": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_153.xml"
+          }
+        ],
+        "Berlay, Montreuil": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_153.xml"
+          }
+        ],
+        "Montreuil's Berlay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_153.xml"
+          }
+        ]
       }
     },
     {
@@ -252,6 +484,44 @@
           "person/item_154.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Fulk of Plessis-Macé": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_154.xml"
+          }
+        ],
+        "Fulk": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_154.xml"
+          }
+        ],
+        "Fulk (Plessis-Macé)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_154.xml"
+          }
+        ],
+        "Fulk of Plessis-Mace": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_154.xml"
+          }
+        ],
+        "Fulk, Plessis-Macé": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_154.xml"
+          }
+        ],
+        "Plessis-Macé's Fulk": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_154.xml"
+          }
+        ]
       }
     },
     {
@@ -289,6 +559,38 @@
           "person/item_156.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Guy Tortus of Rochefort": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_156.xml"
+          }
+        ],
+        "Guy Tortus": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_156.xml"
+          }
+        ],
+        "Guy Tortus (Rochefort)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_156.xml"
+          }
+        ],
+        "Guy Tortus, Rochefort": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_156.xml"
+          }
+        ],
+        "Rochefort's Guy Tortus": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_156.xml"
+          }
+        ]
       }
     },
     {
@@ -319,6 +621,14 @@
           "person/item_157.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "R. Gabard": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_157.xml"
+          }
+        ]
       }
     },
     {
@@ -357,6 +667,44 @@
           "person/item_158.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Rainald of Martigné": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_158.xml"
+          }
+        ],
+        "Martigné's Rainald": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_158.xml"
+          }
+        ],
+        "Rainald": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_158.xml"
+          }
+        ],
+        "Rainald (Martigné)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_158.xml"
+          }
+        ],
+        "Rainald of Martigne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_158.xml"
+          }
+        ],
+        "Rainald, Martigné": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_158.xml"
+          }
+        ]
       }
     },
     {
@@ -391,6 +739,26 @@
           "person/item_159.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William the Huntsman": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_159.xml"
+          }
+        ],
+        "William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_159.xml"
+          }
+        ],
+        "William (Huntsman)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_159.xml"
+          }
+        ]
       }
     },
     {
@@ -435,6 +803,56 @@
           "person/item_160.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Henry I of Troyes, count of Champagne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_160.xml"
+          }
+        ],
+        "Henry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_160.xml"
+          }
+        ],
+        "Henry (Troyes, count of Champagne)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_160.xml"
+          }
+        ],
+        "Henry 1": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_160.xml"
+          }
+        ],
+        "Henry 1 of Troyes, count of Champagne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_160.xml"
+          }
+        ],
+        "Henry I": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_160.xml"
+          }
+        ],
+        "Henry, Troyes, count of Champagne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_160.xml"
+          }
+        ],
+        "Troyes, count of Champagne's Henry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_160.xml"
+          }
+        ]
       }
     },
     {
@@ -472,6 +890,38 @@
           "person/item_161.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hugh of Troyes": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_161.xml"
+          }
+        ],
+        "Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_161.xml"
+          }
+        ],
+        "Hugh (Troyes)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_161.xml"
+          }
+        ],
+        "Hugh, Troyes": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_161.xml"
+          }
+        ],
+        "Troyes's Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_161.xml"
+          }
+        ]
       }
     },
     {
@@ -516,6 +966,56 @@
           "person/item_162.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Erard I of Brienne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_162.xml"
+          }
+        ],
+        "Brienne's Erard": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_162.xml"
+          }
+        ],
+        "Erard": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_162.xml"
+          }
+        ],
+        "Erard (Brienne)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_162.xml"
+          }
+        ],
+        "Erard 1": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_162.xml"
+          }
+        ],
+        "Erard 1 of Brienne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_162.xml"
+          }
+        ],
+        "Erard I": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_162.xml"
+          }
+        ],
+        "Erard, Brienne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_162.xml"
+          }
+        ]
       }
     },
     {
@@ -547,6 +1047,20 @@
           "person/item_163.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Sigurd Magnússon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_163.xml"
+          }
+        ],
+        "Sigurd Magnusson": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_163.xml"
+          }
+        ]
       }
     },
     {
@@ -584,6 +1098,38 @@
           "person/item_164.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Thierry of Flanders": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_164.xml"
+          }
+        ],
+        "Flanders's Thierry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_164.xml"
+          }
+        ],
+        "Thierry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_164.xml"
+          }
+        ],
+        "Thierry (Flanders)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_164.xml"
+          }
+        ],
+        "Thierry, Flanders": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_164.xml"
+          }
+        ]
       }
     },
     {
@@ -621,6 +1167,38 @@
           "person/item_165.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Walter of Hereford": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_165.xml"
+          }
+        ],
+        "Hereford's Walter": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_165.xml"
+          }
+        ],
+        "Walter": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_165.xml"
+          }
+        ],
+        "Walter (Hereford)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_165.xml"
+          }
+        ],
+        "Walter, Hereford": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_165.xml"
+          }
+        ]
       }
     },
     {
@@ -658,6 +1236,38 @@
           "person/item_166.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hugh of Chaumont-sur-Loire": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_166.xml"
+          }
+        ],
+        "Chaumont-sur-Loire's Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_166.xml"
+          }
+        ],
+        "Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_166.xml"
+          }
+        ],
+        "Hugh (Chaumont-sur-Loire)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_166.xml"
+          }
+        ],
+        "Hugh, Chaumont-sur-Loire": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_166.xml"
+          }
+        ]
       }
     },
     {
@@ -692,6 +1302,26 @@
           "person/item_167.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Chalo the Red": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_167.xml"
+          }
+        ],
+        "Chalo": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_167.xml"
+          }
+        ],
+        "Chalo (Red)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_167.xml"
+          }
+        ]
       }
     },
     {
@@ -729,6 +1359,38 @@
           "person/item_168.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Manasses of Hierges": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_168.xml"
+          }
+        ],
+        "Hierges's Manasses": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_168.xml"
+          }
+        ],
+        "Manasses": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_168.xml"
+          }
+        ],
+        "Manasses (Hierges)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_168.xml"
+          }
+        ],
+        "Manasses, Hierges": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_168.xml"
+          }
+        ]
       }
     },
     {
@@ -773,6 +1435,56 @@
           "person/item_169.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hugh III of Le Puisset": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_169.xml"
+          }
+        ],
+        "Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_169.xml"
+          }
+        ],
+        "Hugh (Le Puisset)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_169.xml"
+          }
+        ],
+        "Hugh 3": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_169.xml"
+          }
+        ],
+        "Hugh 3 of Le Puisset": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_169.xml"
+          }
+        ],
+        "Hugh III": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_169.xml"
+          }
+        ],
+        "Hugh, Le Puisset": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_169.xml"
+          }
+        ],
+        "Le Puisset's Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_169.xml"
+          }
+        ]
       }
     },
     {
@@ -810,6 +1522,38 @@
           "person/item_170.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Ansculf of Senots": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_170.xml"
+          }
+        ],
+        "Ansculf": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_170.xml"
+          }
+        ],
+        "Ansculf (Senots)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_170.xml"
+          }
+        ],
+        "Ansculf, Senots": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_170.xml"
+          }
+        ],
+        "Senots's Ansculf": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_170.xml"
+          }
+        ]
       }
     },
     {
@@ -844,6 +1588,26 @@
           "person/item_171.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Ralph the Dog": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_171.xml"
+          }
+        ],
+        "Ralph": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_171.xml"
+          }
+        ],
+        "Ralph (Dog)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_171.xml"
+          }
+        ]
       }
     },
     {
@@ -881,6 +1645,38 @@
           "person/item_172.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Ralph of Dury": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_172.xml"
+          }
+        ],
+        "Dury's Ralph": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_172.xml"
+          }
+        ],
+        "Ralph": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_172.xml"
+          }
+        ],
+        "Ralph (Dury)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_172.xml"
+          }
+        ],
+        "Ralph, Dury": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_172.xml"
+          }
+        ]
       }
     },
     {
@@ -925,6 +1721,56 @@
           "person/item_173.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Enguerran II of Coucy": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_173.xml"
+          }
+        ],
+        "Coucy's Enguerran": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_173.xml"
+          }
+        ],
+        "Enguerran": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_173.xml"
+          }
+        ],
+        "Enguerran (Coucy)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_173.xml"
+          }
+        ],
+        "Enguerran 2": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_173.xml"
+          }
+        ],
+        "Enguerran 2 of Coucy": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_173.xml"
+          }
+        ],
+        "Enguerran II": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_173.xml"
+          }
+        ],
+        "Enguerran, Coucy": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_173.xml"
+          }
+        ]
       }
     },
     {
@@ -959,6 +1805,26 @@
           "person/item_174.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Henry the Lion": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_174.xml"
+          }
+        ],
+        "Henry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_174.xml"
+          }
+        ],
+        "Henry (Lion)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_174.xml"
+          }
+        ]
       }
     },
     {
@@ -996,6 +1862,38 @@
           "person/item_175.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Philip of Flanders": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_175.xml"
+          }
+        ],
+        "Flanders's Philip": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_175.xml"
+          }
+        ],
+        "Philip": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_175.xml"
+          }
+        ],
+        "Philip (Flanders)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_175.xml"
+          }
+        ],
+        "Philip, Flanders": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_175.xml"
+          }
+        ]
       }
     },
     {
@@ -1033,6 +1931,38 @@
           "person/item_176.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Rudolf of Pfullendorf": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_176.xml"
+          }
+        ],
+        "Pfullendorf's Rudolf": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_176.xml"
+          }
+        ],
+        "Rudolf": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_176.xml"
+          }
+        ],
+        "Rudolf (Pfullendorf)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_176.xml"
+          }
+        ],
+        "Rudolf, Pfullendorf": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_176.xml"
+          }
+        ]
       }
     },
     {
@@ -1070,6 +2000,38 @@
           "person/item_178.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Rognvald of Orkney": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_178.xml"
+          }
+        ],
+        "Orkney's Rognvald": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_178.xml"
+          }
+        ],
+        "Rognvald": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_178.xml"
+          }
+        ],
+        "Rognvald (Orkney)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_178.xml"
+          }
+        ],
+        "Rognvald, Orkney": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_178.xml"
+          }
+        ]
       }
     },
     {
@@ -1107,6 +2069,38 @@
           "person/item_180.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William of Tortosa": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_180.xml"
+          }
+        ],
+        "Tortosa's William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_180.xml"
+          }
+        ],
+        "William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_180.xml"
+          }
+        ],
+        "William (Tortosa)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_180.xml"
+          }
+        ],
+        "William, Tortosa": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_180.xml"
+          }
+        ]
       }
     },
     {
@@ -1144,6 +2138,38 @@
           "person/item_181.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Charles of Denmark": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_181.xml"
+          }
+        ],
+        "Charles": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_181.xml"
+          }
+        ],
+        "Charles (Denmark)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_181.xml"
+          }
+        ],
+        "Charles, Denmark": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_181.xml"
+          }
+        ],
+        "Denmark's Charles": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_181.xml"
+          }
+        ]
       }
     },
     {
@@ -1174,6 +2200,14 @@
           "person/item_182.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William Marshal": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_182.xml"
+          }
+        ]
       }
     },
     {
@@ -1204,6 +2238,14 @@
           "person/item_183.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Sancho Martin": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_183.xml"
+          }
+        ]
       }
     },
     {
@@ -1241,6 +2283,38 @@
           "person/item_184.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Conrad of Montferrat": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_184.xml"
+          }
+        ],
+        "Conrad": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_184.xml"
+          }
+        ],
+        "Conrad (Montferrat)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_184.xml"
+          }
+        ],
+        "Conrad, Montferrat": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_184.xml"
+          }
+        ],
+        "Montferrat's Conrad": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_184.xml"
+          }
+        ]
       }
     },
     {
@@ -1278,6 +2352,38 @@
           "person/item_186.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hugh of Payns": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_186.xml"
+          }
+        ],
+        "Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_186.xml"
+          }
+        ],
+        "Hugh (Payns)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_186.xml"
+          }
+        ],
+        "Hugh, Payns": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_186.xml"
+          }
+        ],
+        "Payns's Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_186.xml"
+          }
+        ]
       }
     },
     {
@@ -1309,6 +2415,20 @@
           "person/item_187.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Arni Fjöruskeiv": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_187.xml"
+          }
+        ],
+        "Arni Fjoruskeiv": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_187.xml"
+          }
+        ]
       }
     },
     {
@@ -1340,6 +2460,20 @@
           "person/item_188.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Áláskr Hani": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_188.xml"
+          }
+        ],
+        "Alaskr Hani": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_188.xml"
+          }
+        ]
       }
     },
     {
@@ -1378,6 +2512,44 @@
           "person/item_189.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hámundr Thorvaldsson of Vatnsfjord": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_189.xml"
+          }
+        ],
+        "Hamundr Thorvaldsson of Vatnsfjord": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_189.xml"
+          }
+        ],
+        "Hámundr Thorvaldsson": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_189.xml"
+          }
+        ],
+        "Hámundr Thorvaldsson (Vatnsfjord)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_189.xml"
+          }
+        ],
+        "Hámundr Thorvaldsson, Vatnsfjord": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_189.xml"
+          }
+        ],
+        "Vatnsfjord's Hámundr Thorvaldsson": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_189.xml"
+          }
+        ]
       }
     },
     {
@@ -1416,6 +2588,44 @@
           "person/item_190.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Rainald of St Valéry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_190.xml"
+          }
+        ],
+        "Rainald": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_190.xml"
+          }
+        ],
+        "Rainald (St Valéry)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_190.xml"
+          }
+        ],
+        "Rainald of St Valery": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_190.xml"
+          }
+        ],
+        "Rainald, St Valéry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_190.xml"
+          }
+        ],
+        "St Valéry's Rainald": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_190.xml"
+          }
+        ]
       }
     },
     {
@@ -1453,6 +2663,38 @@
           "person/item_191.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William of Orkney": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_191.xml"
+          }
+        ],
+        "Orkney's William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_191.xml"
+          }
+        ],
+        "William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_191.xml"
+          }
+        ],
+        "William (Orkney)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_191.xml"
+          }
+        ],
+        "William, Orkney": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_191.xml"
+          }
+        ]
       }
     },
     {
@@ -1487,6 +2729,26 @@
           "person/item_192.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Eindridi the Young": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_192.xml"
+          }
+        ],
+        "Eindridi": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_192.xml"
+          }
+        ],
+        "Eindridi (Young)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_192.xml"
+          }
+        ]
       }
     },
     {
@@ -1514,6 +2776,14 @@
           "person/item_193.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Armod": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_193.xml"
+          }
+        ]
       }
     },
     {
@@ -1544,6 +2814,14 @@
           "person/item_194.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Erling Wry-neck": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_194.xml"
+          }
+        ]
       }
     },
     {
@@ -1574,6 +2852,14 @@
           "person/item_195.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William de Mandeville": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_195.xml"
+          }
+        ]
       }
     },
     {
@@ -1604,6 +2890,14 @@
           "person/item_196.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William Rex": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_196.xml"
+          }
+        ]
       }
     },
     {
@@ -1638,6 +2932,26 @@
           "person/item_197.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Artaud the Chamberlain": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_197.xml"
+          }
+        ],
+        "Artaud": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_197.xml"
+          }
+        ],
+        "Artaud (Chamberlain)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_197.xml"
+          }
+        ]
       }
     },
     {
@@ -1675,6 +2989,38 @@
           "person/item_198.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Thibaud of Fismes": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_198.xml"
+          }
+        ],
+        "Fismes's Thibaud": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_198.xml"
+          }
+        ],
+        "Thibaud": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_198.xml"
+          }
+        ],
+        "Thibaud (Fismes)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_198.xml"
+          }
+        ],
+        "Thibaud, Fismes": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_198.xml"
+          }
+        ]
       }
     },
     {
@@ -1713,6 +3059,44 @@
           "person/item_199.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Philip of Sézanne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_199.xml"
+          }
+        ],
+        "Philip": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_199.xml"
+          }
+        ],
+        "Philip (Sézanne)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_199.xml"
+          }
+        ],
+        "Philip of Sezanne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_199.xml"
+          }
+        ],
+        "Philip, Sézanne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_199.xml"
+          }
+        ],
+        "Sézanne's Philip": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_199.xml"
+          }
+        ]
       }
     },
     {
@@ -1750,6 +3134,38 @@
           "person/item_200.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Peter of Langres": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_200.xml"
+          }
+        ],
+        "Langres's Peter": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_200.xml"
+          }
+        ],
+        "Peter": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_200.xml"
+          }
+        ],
+        "Peter (Langres)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_200.xml"
+          }
+        ],
+        "Peter, Langres": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_200.xml"
+          }
+        ]
       }
     },
     {
@@ -1788,6 +3204,44 @@
           "person/item_201.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Henry of Grandpré": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_201.xml"
+          }
+        ],
+        "Grandpré's Henry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_201.xml"
+          }
+        ],
+        "Henry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_201.xml"
+          }
+        ],
+        "Henry (Grandpré)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_201.xml"
+          }
+        ],
+        "Henry of Grandpre": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_201.xml"
+          }
+        ],
+        "Henry, Grandpré": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_201.xml"
+          }
+        ]
       }
     },
     {
@@ -1826,6 +3280,44 @@
           "person/item_202.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Geoffrey of Grandpré": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_202.xml"
+          }
+        ],
+        "Geoffrey": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_202.xml"
+          }
+        ],
+        "Geoffrey (Grandpré)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_202.xml"
+          }
+        ],
+        "Geoffrey of Grandpre": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_202.xml"
+          }
+        ],
+        "Geoffrey, Grandpré": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_202.xml"
+          }
+        ],
+        "Grandpré's Geoffrey": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_202.xml"
+          }
+        ]
       }
     },
     {
@@ -1863,6 +3355,38 @@
           "person/item_203.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Robert of Milly": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_203.xml"
+          }
+        ],
+        "Milly's Robert": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_203.xml"
+          }
+        ],
+        "Robert": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_203.xml"
+          }
+        ],
+        "Robert (Milly)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_203.xml"
+          }
+        ],
+        "Robert, Milly": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_203.xml"
+          }
+        ]
       }
     },
     {
@@ -1900,6 +3424,38 @@
           "person/item_204.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Milo I Breban of Provins": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_204.xml"
+          }
+        ],
+        "Milo I Breban": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_204.xml"
+          }
+        ],
+        "Milo I Breban (Provins)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_204.xml"
+          }
+        ],
+        "Milo I Breban, Provins": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_204.xml"
+          }
+        ],
+        "Provins's Milo I Breban": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_204.xml"
+          }
+        ]
       }
     },
     {
@@ -1937,6 +3493,38 @@
           "person/item_205.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William of Sainte-Maure": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_205.xml"
+          }
+        ],
+        "Sainte-Maure's William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_205.xml"
+          }
+        ],
+        "William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_205.xml"
+          }
+        ],
+        "William (Sainte-Maure)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_205.xml"
+          }
+        ],
+        "William, Sainte-Maure": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_205.xml"
+          }
+        ]
       }
     },
     {
@@ -1974,6 +3562,38 @@
           "person/item_206.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hugh of Lizy": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_206.xml"
+          }
+        ],
+        "Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_206.xml"
+          }
+        ],
+        "Hugh (Lizy)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_206.xml"
+          }
+        ],
+        "Hugh, Lizy": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_206.xml"
+          }
+        ],
+        "Lizy's Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_206.xml"
+          }
+        ]
       }
     },
     {
@@ -2012,6 +3632,44 @@
           "person/item_207.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Nicholas of Montiéramey": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_207.xml"
+          }
+        ],
+        "Montiéramey's Nicholas": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_207.xml"
+          }
+        ],
+        "Nicholas": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_207.xml"
+          }
+        ],
+        "Nicholas (Montiéramey)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_207.xml"
+          }
+        ],
+        "Nicholas of Montieramey": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_207.xml"
+          }
+        ],
+        "Nicholas, Montiéramey": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_207.xml"
+          }
+        ]
       }
     },
     {
@@ -2042,6 +3700,14 @@
           "person/item_208.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Peter Britaud": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_208.xml"
+          }
+        ]
       }
     },
     {
@@ -2086,6 +3752,56 @@
           "person/item_209.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Peter I of Courtenay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_209.xml"
+          }
+        ],
+        "Courtenay's Peter": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_209.xml"
+          }
+        ],
+        "Peter": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_209.xml"
+          }
+        ],
+        "Peter (Courtenay)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_209.xml"
+          }
+        ],
+        "Peter 1": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_209.xml"
+          }
+        ],
+        "Peter 1 of Courtenay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_209.xml"
+          }
+        ],
+        "Peter I": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_209.xml"
+          }
+        ],
+        "Peter, Courtenay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_209.xml"
+          }
+        ]
       }
     },
     {
@@ -2123,6 +3839,38 @@
           "person/item_210.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Philip of Dreux, bishop of Beavais": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_210.xml"
+          }
+        ],
+        "Dreux, bishop of Beavais's Philip": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_210.xml"
+          }
+        ],
+        "Philip": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_210.xml"
+          }
+        ],
+        "Philip (Dreux, bishop of Beavais)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_210.xml"
+          }
+        ],
+        "Philip, Dreux, bishop of Beavais": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_210.xml"
+          }
+        ]
       }
     },
     {
@@ -2153,6 +3901,14 @@
           "person/item_211.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Aslak Erlendsson": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_211.xml"
+          }
+        ]
       }
     },
     {
@@ -2183,6 +3939,14 @@
           "person/item_212.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Guthorm Mjolukoll": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_212.xml"
+          }
+        ]
       }
     },
     {
@@ -2213,6 +3977,14 @@
           "person/item_213.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Magnus Havardsson": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_213.xml"
+          }
+        ]
       }
     },
     {
@@ -2243,6 +4015,14 @@
           "person/item_214.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Svein Hroaldsson": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_214.xml"
+          }
+        ]
       }
     },
     {
@@ -2277,6 +4057,26 @@
           "person/item_215.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Oddi the Little": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_215.xml"
+          }
+        ],
+        "Oddi": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_215.xml"
+          }
+        ],
+        "Oddi (Little)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_215.xml"
+          }
+        ]
       }
     },
     {
@@ -2307,6 +4107,14 @@
           "person/item_216.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Sigmund Fish-Hook": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_216.xml"
+          }
+        ]
       }
     },
     {
@@ -2341,6 +4149,26 @@
           "person/item_217.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Thorbjorn the Black": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_217.xml"
+          }
+        ],
+        "Thorbjorn": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_217.xml"
+          }
+        ],
+        "Thorbjorn (Black)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_217.xml"
+          }
+        ]
       }
     },
     {
@@ -2378,6 +4206,38 @@
           "person/item_218.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "James of Chacenay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_218.xml"
+          }
+        ],
+        "Chacenay's James": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_218.xml"
+          }
+        ],
+        "James": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_218.xml"
+          }
+        ],
+        "James (Chacenay)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_218.xml"
+          }
+        ],
+        "James, Chacenay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_218.xml"
+          }
+        ]
       }
     },
     {
@@ -2422,6 +4282,56 @@
           "person/item_219.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Anseric II of Chacenay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_219.xml"
+          }
+        ],
+        "Anseric": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_219.xml"
+          }
+        ],
+        "Anseric (Chacenay)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_219.xml"
+          }
+        ],
+        "Anseric 2": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_219.xml"
+          }
+        ],
+        "Anseric 2 of Chacenay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_219.xml"
+          }
+        ],
+        "Anseric II": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_219.xml"
+          }
+        ],
+        "Anseric, Chacenay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_219.xml"
+          }
+        ],
+        "Chacenay's Anseric": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_219.xml"
+          }
+        ]
       }
     },
     {
@@ -2459,6 +4369,38 @@
           "person/item_220.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William of Biron": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_220.xml"
+          }
+        ],
+        "Biron's William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_220.xml"
+          }
+        ],
+        "William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_220.xml"
+          }
+        ],
+        "William (Biron)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_220.xml"
+          }
+        ],
+        "William, Biron": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_220.xml"
+          }
+        ]
       }
     },
     {
@@ -2496,6 +4438,38 @@
           "person/item_221.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Grimoard of St. Germain": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_221.xml"
+          }
+        ],
+        "Grimoard": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_221.xml"
+          }
+        ],
+        "Grimoard (St. Germain)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_221.xml"
+          }
+        ],
+        "Grimoard, St. Germain": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_221.xml"
+          }
+        ],
+        "St. Germain's Grimoard": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_221.xml"
+          }
+        ]
       }
     },
     {
@@ -2526,6 +4500,14 @@
           "person/item_2327.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hugh de Beauchamp": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2327.xml"
+          }
+        ]
       }
     },
     {
@@ -2556,6 +4538,14 @@
           "person/item_2328.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Roger de Mowbray": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2328.xml"
+          }
+        ]
       }
     },
     {
@@ -2586,6 +4576,14 @@
           "person/item_2337.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Jon Petersson": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2337.xml"
+          }
+        ]
       }
     },
     {
@@ -2630,6 +4628,56 @@
           "person/item_2339.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Godfrey III of Louvain": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2339.xml"
+          }
+        ],
+        "Godfrey": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2339.xml"
+          }
+        ],
+        "Godfrey (Louvain)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2339.xml"
+          }
+        ],
+        "Godfrey 3": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2339.xml"
+          }
+        ],
+        "Godfrey 3 of Louvain": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2339.xml"
+          }
+        ],
+        "Godfrey III": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2339.xml"
+          }
+        ],
+        "Godfrey, Louvain": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2339.xml"
+          }
+        ],
+        "Louvain's Godfrey": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2339.xml"
+          }
+        ]
       }
     },
     {
@@ -2667,6 +4715,38 @@
           "person/item_2340.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Gilles of Chimay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2340.xml"
+          }
+        ],
+        "Chimay's Gilles": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2340.xml"
+          }
+        ],
+        "Gilles": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2340.xml"
+          }
+        ],
+        "Gilles (Chimay)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2340.xml"
+          }
+        ],
+        "Gilles, Chimay": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2340.xml"
+          }
+        ]
       }
     },
     {
@@ -2711,6 +4791,56 @@
           "person/item_2341.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Gerard II of Looz": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2341.xml"
+          }
+        ],
+        "Gerard": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2341.xml"
+          }
+        ],
+        "Gerard (Looz)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2341.xml"
+          }
+        ],
+        "Gerard 2": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2341.xml"
+          }
+        ],
+        "Gerard 2 of Looz": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2341.xml"
+          }
+        ],
+        "Gerard II": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2341.xml"
+          }
+        ],
+        "Gerard, Looz": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2341.xml"
+          }
+        ],
+        "Looz's Gerard": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2341.xml"
+          }
+        ]
       }
     },
     {
@@ -2742,6 +4872,20 @@
           "person/item_2344.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Rodrigo Álvarez de Sarria": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2344.xml"
+          }
+        ],
+        "Rodrigo Alvarez de Sarria": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2344.xml"
+          }
+        ]
       }
     },
     {
@@ -2779,6 +4923,38 @@
           "person/item_2345.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Henry of Portugal": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2345.xml"
+          }
+        ],
+        "Henry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2345.xml"
+          }
+        ],
+        "Henry (Portugal)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2345.xml"
+          }
+        ],
+        "Henry, Portugal": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2345.xml"
+          }
+        ],
+        "Portugal's Henry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2345.xml"
+          }
+        ]
       }
     },
     {
@@ -2823,6 +4999,56 @@
           "person/item_2350.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Maurice II of Craon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2350.xml"
+          }
+        ],
+        "Craon's Maurice": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2350.xml"
+          }
+        ],
+        "Maurice": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2350.xml"
+          }
+        ],
+        "Maurice (Craon)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2350.xml"
+          }
+        ],
+        "Maurice 2": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2350.xml"
+          }
+        ],
+        "Maurice 2 of Craon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2350.xml"
+          }
+        ],
+        "Maurice II": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2350.xml"
+          }
+        ],
+        "Maurice, Craon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2350.xml"
+          }
+        ]
       }
     },
     {
@@ -2860,6 +5086,38 @@
           "person/item_2353.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Margaret of Beverley": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2353.xml"
+          }
+        ],
+        "Beverley's Margaret": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2353.xml"
+          }
+        ],
+        "Margaret": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2353.xml"
+          }
+        ],
+        "Margaret (Beverley)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2353.xml"
+          }
+        ],
+        "Margaret, Beverley": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2353.xml"
+          }
+        ]
       }
     },
     {
@@ -2905,6 +5163,62 @@
           "person/item_2355.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William III of Mâcon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2355.xml"
+          }
+        ],
+        "Mâcon's William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2355.xml"
+          }
+        ],
+        "William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2355.xml"
+          }
+        ],
+        "William (Mâcon)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2355.xml"
+          }
+        ],
+        "William 3": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2355.xml"
+          }
+        ],
+        "William 3 of Mâcon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2355.xml"
+          }
+        ],
+        "William III": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2355.xml"
+          }
+        ],
+        "William III of Macon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2355.xml"
+          }
+        ],
+        "William, Mâcon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2355.xml"
+          }
+        ]
       }
     },
     {
@@ -2950,6 +5264,62 @@
           "person/item_2356.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Andrew II of Vitré": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2356.xml"
+          }
+        ],
+        "Andrew": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2356.xml"
+          }
+        ],
+        "Andrew (Vitré)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2356.xml"
+          }
+        ],
+        "Andrew 2": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2356.xml"
+          }
+        ],
+        "Andrew 2 of Vitré": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2356.xml"
+          }
+        ],
+        "Andrew II": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2356.xml"
+          }
+        ],
+        "Andrew II of Vitre": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2356.xml"
+          }
+        ],
+        "Andrew, Vitré": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2356.xml"
+          }
+        ],
+        "Vitré's Andrew": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2356.xml"
+          }
+        ]
       }
     },
     {
@@ -2987,6 +5357,38 @@
           "person/item_2358.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Walter of St. Omer": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2358.xml"
+          }
+        ],
+        "St. Omer's Walter": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2358.xml"
+          }
+        ],
+        "Walter": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2358.xml"
+          }
+        ],
+        "Walter (St. Omer)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2358.xml"
+          }
+        ],
+        "Walter, St. Omer": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2358.xml"
+          }
+        ]
       }
     },
     {
@@ -3031,6 +5433,56 @@
           "person/item_2359.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Audebert IV of La Marche": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2359.xml"
+          }
+        ],
+        "Audebert": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2359.xml"
+          }
+        ],
+        "Audebert (La Marche)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2359.xml"
+          }
+        ],
+        "Audebert 4": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2359.xml"
+          }
+        ],
+        "Audebert 4 of La Marche": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2359.xml"
+          }
+        ],
+        "Audebert IV": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2359.xml"
+          }
+        ],
+        "Audebert, La Marche": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2359.xml"
+          }
+        ],
+        "La Marche's Audebert": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2359.xml"
+          }
+        ]
       }
     },
     {
@@ -3075,6 +5527,56 @@
           "person/item_2360.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William IV of Nevers": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2360.xml"
+          }
+        ],
+        "Nevers's William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2360.xml"
+          }
+        ],
+        "William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2360.xml"
+          }
+        ],
+        "William (Nevers)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2360.xml"
+          }
+        ],
+        "William 4": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2360.xml"
+          }
+        ],
+        "William 4 of Nevers": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2360.xml"
+          }
+        ],
+        "William IV": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2360.xml"
+          }
+        ],
+        "William, Nevers": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2360.xml"
+          }
+        ]
       }
     },
     {
@@ -3120,6 +5622,62 @@
           "person/item_2361.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Ralph II of Fougères": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2361.xml"
+          }
+        ],
+        "Fougères's Ralph": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2361.xml"
+          }
+        ],
+        "Ralph": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2361.xml"
+          }
+        ],
+        "Ralph (Fougères)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2361.xml"
+          }
+        ],
+        "Ralph 2": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2361.xml"
+          }
+        ],
+        "Ralph 2 of Fougères": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2361.xml"
+          }
+        ],
+        "Ralph II": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2361.xml"
+          }
+        ],
+        "Ralph II of Fougeres": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2361.xml"
+          }
+        ],
+        "Ralph, Fougères": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2361.xml"
+          }
+        ]
       }
     },
     {
@@ -3150,6 +5708,14 @@
           "person/item_2362.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Peire Bremon lo Tort": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2362.xml"
+          }
+        ]
       }
     },
     {
@@ -3180,6 +5746,14 @@
           "person/item_2363.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Giraut de Borneil": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2363.xml"
+          }
+        ]
       }
     },
     {
@@ -3210,6 +5784,14 @@
           "person/item_2364.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Peire Vidal": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2364.xml"
+          }
+        ]
       }
     },
     {
@@ -3247,6 +5829,38 @@
           "person/item_2365.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Arnold of Wezemaal": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2365.xml"
+          }
+        ],
+        "Arnold": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2365.xml"
+          }
+        ],
+        "Arnold (Wezemaal)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2365.xml"
+          }
+        ],
+        "Arnold, Wezemaal": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2365.xml"
+          }
+        ],
+        "Wezemaal's Arnold": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2365.xml"
+          }
+        ]
       }
     },
     {
@@ -3284,6 +5898,38 @@
           "person/item_2366.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Louis of Hesbaye": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2366.xml"
+          }
+        ],
+        "Hesbaye's Louis": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2366.xml"
+          }
+        ],
+        "Louis": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2366.xml"
+          }
+        ],
+        "Louis (Hesbaye)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2366.xml"
+          }
+        ],
+        "Louis, Hesbaye": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2366.xml"
+          }
+        ]
       }
     },
     {
@@ -3321,6 +5967,38 @@
           "person/item_2367.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Henry of Limal": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2367.xml"
+          }
+        ],
+        "Henry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2367.xml"
+          }
+        ],
+        "Henry (Limal)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2367.xml"
+          }
+        ],
+        "Henry, Limal": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2367.xml"
+          }
+        ],
+        "Limal's Henry": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2367.xml"
+          }
+        ]
       }
     },
     {
@@ -3358,6 +6036,38 @@
           "person/item_2368.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Benedict of Zandhoven": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2368.xml"
+          }
+        ],
+        "Benedict": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2368.xml"
+          }
+        ],
+        "Benedict (Zandhoven)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2368.xml"
+          }
+        ],
+        "Benedict, Zandhoven": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2368.xml"
+          }
+        ],
+        "Zandhoven's Benedict": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2368.xml"
+          }
+        ]
       }
     },
     {
@@ -3392,6 +6102,26 @@
           "person/item_2369.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Gosuin the Goat": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2369.xml"
+          }
+        ],
+        "Gosuin": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2369.xml"
+          }
+        ],
+        "Gosuin (Goat)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2369.xml"
+          }
+        ]
       }
     },
     {
@@ -3429,6 +6159,38 @@
           "person/item_2370.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Frizo of Glabbeek": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2370.xml"
+          }
+        ],
+        "Frizo": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2370.xml"
+          }
+        ],
+        "Frizo (Glabbeek)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2370.xml"
+          }
+        ],
+        "Frizo, Glabbeek": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2370.xml"
+          }
+        ],
+        "Glabbeek's Frizo": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2370.xml"
+          }
+        ]
       }
     },
     {
@@ -3466,6 +6228,38 @@
           "person/item_2371.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Matthew of Bellenoue": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2371.xml"
+          }
+        ],
+        "Bellenoue's Matthew": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2371.xml"
+          }
+        ],
+        "Matthew": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2371.xml"
+          }
+        ],
+        "Matthew (Bellenoue)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2371.xml"
+          }
+        ],
+        "Matthew, Bellenoue": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2371.xml"
+          }
+        ]
       }
     },
     {
@@ -3504,6 +6298,44 @@
           "person/item_2374.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Robert of Buzançais": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2374.xml"
+          }
+        ],
+        "Buzançais's Robert": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2374.xml"
+          }
+        ],
+        "Robert": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2374.xml"
+          }
+        ],
+        "Robert (Buzançais)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2374.xml"
+          }
+        ],
+        "Robert of Buzancais": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2374.xml"
+          }
+        ],
+        "Robert, Buzançais": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2374.xml"
+          }
+        ]
       }
     },
     {
@@ -3541,6 +6373,38 @@
           "person/item_2375.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Berthold of Sperberseck": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2375.xml"
+          }
+        ],
+        "Berthold": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2375.xml"
+          }
+        ],
+        "Berthold (Sperberseck)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2375.xml"
+          }
+        ],
+        "Berthold, Sperberseck": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2375.xml"
+          }
+        ],
+        "Sperberseck's Berthold": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2375.xml"
+          }
+        ]
       }
     },
     {
@@ -3585,6 +6449,56 @@
           "person/item_2376.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William V of Montferrat": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2376.xml"
+          }
+        ],
+        "Montferrat's William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2376.xml"
+          }
+        ],
+        "William": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2376.xml"
+          }
+        ],
+        "William (Montferrat)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2376.xml"
+          }
+        ],
+        "William 5": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2376.xml"
+          }
+        ],
+        "William 5 of Montferrat": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2376.xml"
+          }
+        ],
+        "William V": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2376.xml"
+          }
+        ],
+        "William, Montferrat": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2376.xml"
+          }
+        ]
       }
     },
     {
@@ -3619,6 +6533,26 @@
           "person/item_2377.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Rainald the Proud": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2377.xml"
+          }
+        ],
+        "Rainald": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2377.xml"
+          }
+        ],
+        "Rainald (Proud)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2377.xml"
+          }
+        ]
       }
     },
     {
@@ -3656,6 +6590,38 @@
           "person/item_2378.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hugh of Matheflon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2378.xml"
+          }
+        ],
+        "Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2378.xml"
+          }
+        ],
+        "Hugh (Matheflon)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2378.xml"
+          }
+        ],
+        "Hugh, Matheflon": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2378.xml"
+          }
+        ],
+        "Matheflon's Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2378.xml"
+          }
+        ]
       }
     },
     {
@@ -3693,6 +6659,38 @@
           "person/item_2379.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Sibylla of Anjou": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2379.xml"
+          }
+        ],
+        "Anjou's Sibylla": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2379.xml"
+          }
+        ],
+        "Sibylla": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2379.xml"
+          }
+        ],
+        "Sibylla (Anjou)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2379.xml"
+          }
+        ],
+        "Sibylla, Anjou": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2379.xml"
+          }
+        ]
       }
     },
     {
@@ -3737,6 +6735,56 @@
           "person/item_2380.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Stephen I of Sancerre": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2380.xml"
+          }
+        ],
+        "Sancerre's Stephen": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2380.xml"
+          }
+        ],
+        "Stephen": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2380.xml"
+          }
+        ],
+        "Stephen (Sancerre)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2380.xml"
+          }
+        ],
+        "Stephen 1": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2380.xml"
+          }
+        ],
+        "Stephen 1 of Sancerre": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2380.xml"
+          }
+        ],
+        "Stephen I": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2380.xml"
+          }
+        ],
+        "Stephen, Sancerre": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2380.xml"
+          }
+        ]
       }
     },
     {
@@ -3781,6 +6829,56 @@
           "person/item_2381.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Stephen II of Auxonne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2381.xml"
+          }
+        ],
+        "Auxonne's Stephen": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2381.xml"
+          }
+        ],
+        "Stephen": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2381.xml"
+          }
+        ],
+        "Stephen (Auxonne)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2381.xml"
+          }
+        ],
+        "Stephen 2": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2381.xml"
+          }
+        ],
+        "Stephen 2 of Auxonne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2381.xml"
+          }
+        ],
+        "Stephen II": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2381.xml"
+          }
+        ],
+        "Stephen, Auxonne": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2381.xml"
+          }
+        ]
       }
     },
     {
@@ -3825,6 +6923,56 @@
           "person/item_2382.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hugh III of Burgundy": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2382.xml"
+          }
+        ],
+        "Burgundy's Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2382.xml"
+          }
+        ],
+        "Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2382.xml"
+          }
+        ],
+        "Hugh (Burgundy)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2382.xml"
+          }
+        ],
+        "Hugh 3": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2382.xml"
+          }
+        ],
+        "Hugh 3 of Burgundy": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2382.xml"
+          }
+        ],
+        "Hugh III": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2382.xml"
+          }
+        ],
+        "Hugh, Burgundy": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2382.xml"
+          }
+        ]
       }
     },
     {
@@ -3870,6 +7018,62 @@
           "person/item_2383.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Adhémar V of Limoges": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2383.xml"
+          }
+        ],
+        "Adhemar V of Limoges": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2383.xml"
+          }
+        ],
+        "Adhémar": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2383.xml"
+          }
+        ],
+        "Adhémar (Limoges)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2383.xml"
+          }
+        ],
+        "Adhémar 5": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2383.xml"
+          }
+        ],
+        "Adhémar 5 of Limoges": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2383.xml"
+          }
+        ],
+        "Adhémar V": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2383.xml"
+          }
+        ],
+        "Adhémar, Limoges": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2383.xml"
+          }
+        ],
+        "Limoges's Adhémar": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2383.xml"
+          }
+        ]
       }
     },
     {
@@ -3914,6 +7118,56 @@
           "person/item_2384.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Dedo IV of Wettin": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2384.xml"
+          }
+        ],
+        "Dedo": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2384.xml"
+          }
+        ],
+        "Dedo (Wettin)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2384.xml"
+          }
+        ],
+        "Dedo 4": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2384.xml"
+          }
+        ],
+        "Dedo 4 of Wettin": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2384.xml"
+          }
+        ],
+        "Dedo IV": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2384.xml"
+          }
+        ],
+        "Dedo, Wettin": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2384.xml"
+          }
+        ],
+        "Wettin's Dedo": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2384.xml"
+          }
+        ]
       }
     },
     {
@@ -3952,6 +7206,44 @@
           "person/item_2385.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William VI, count of Angoulême": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2385.xml"
+          }
+        ],
+        "Angoulême's William VI, count": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2385.xml"
+          }
+        ],
+        "William VI, count": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2385.xml"
+          }
+        ],
+        "William VI, count (Angoulême)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2385.xml"
+          }
+        ],
+        "William VI, count of Angouleme": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2385.xml"
+          }
+        ],
+        "William VI, count, Angoulême": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2385.xml"
+          }
+        ]
       }
     },
     {
@@ -3997,6 +7289,62 @@
           "person/item_2387.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Robert V of Béthune": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2387.xml"
+          }
+        ],
+        "Béthune's Robert": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2387.xml"
+          }
+        ],
+        "Robert": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2387.xml"
+          }
+        ],
+        "Robert (Béthune)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2387.xml"
+          }
+        ],
+        "Robert 5": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2387.xml"
+          }
+        ],
+        "Robert 5 of Béthune": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2387.xml"
+          }
+        ],
+        "Robert V": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2387.xml"
+          }
+        ],
+        "Robert V of Bethune": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2387.xml"
+          }
+        ],
+        "Robert, Béthune": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2387.xml"
+          }
+        ]
       }
     },
     {
@@ -4034,6 +7382,38 @@
           "person/item_2388.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Ermengarde of Anjou": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2388.xml"
+          }
+        ],
+        "Anjou's Ermengarde": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2388.xml"
+          }
+        ],
+        "Ermengarde": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2388.xml"
+          }
+        ],
+        "Ermengarde (Anjou)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2388.xml"
+          }
+        ],
+        "Ermengarde, Anjou": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2388.xml"
+          }
+        ]
       }
     },
     {
@@ -4071,6 +7451,38 @@
           "person/item_2389.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Constance of Toulouse": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2389.xml"
+          }
+        ],
+        "Constance": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2389.xml"
+          }
+        ],
+        "Constance (Toulouse)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2389.xml"
+          }
+        ],
+        "Constance, Toulouse": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2389.xml"
+          }
+        ],
+        "Toulouse's Constance": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2389.xml"
+          }
+        ]
       }
     },
     {
@@ -4102,6 +7514,20 @@
           "person/item_2390.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Fernando Pérez": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2390.xml"
+          }
+        ],
+        "Fernando Perez": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2390.xml"
+          }
+        ]
       }
     },
     {
@@ -4133,6 +7559,20 @@
           "person/item_2391.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Elvira Ramírez": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2391.xml"
+          }
+        ],
+        "Elvira Ramirez": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2391.xml"
+          }
+        ]
       }
     },
     {
@@ -4163,6 +7603,14 @@
           "person/item_2392.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Henry de Lacy": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2392.xml"
+          }
+        ]
       }
     },
     {
@@ -4200,6 +7648,38 @@
           "person/item_2397.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hugh of Lacerta": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2397.xml"
+          }
+        ],
+        "Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2397.xml"
+          }
+        ],
+        "Hugh (Lacerta)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2397.xml"
+          }
+        ],
+        "Hugh, Lacerta": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2397.xml"
+          }
+        ],
+        "Lacerta's Hugh": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2397.xml"
+          }
+        ]
       }
     },
     {
@@ -4231,6 +7711,20 @@
           "person/item_2401.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Rodrigo González de Lara": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2401.xml"
+          }
+        ],
+        "Rodrigo Gonzalez de Lara": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2401.xml"
+          }
+        ]
       }
     },
     {
@@ -4265,6 +7759,26 @@
           "person/item_2402.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Albert the Bear": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2402.xml"
+          }
+        ],
+        "Albert": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2402.xml"
+          }
+        ],
+        "Albert (Bear)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2402.xml"
+          }
+        ]
       }
     },
     {
@@ -4302,6 +7816,38 @@
           "person/item_2403.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Sophie of Winzenburg": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2403.xml"
+          }
+        ],
+        "Sophie": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2403.xml"
+          }
+        ],
+        "Sophie (Winzenburg)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2403.xml"
+          }
+        ],
+        "Sophie, Winzenburg": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2403.xml"
+          }
+        ],
+        "Winzenburg's Sophie": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2403.xml"
+          }
+        ]
       }
     },
     {
@@ -4339,6 +7885,38 @@
           "person/item_2404.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Hroznata, son of Herman": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2404.xml"
+          }
+        ],
+        "Herman's Hroznata, son": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2404.xml"
+          }
+        ],
+        "Hroznata, son": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2404.xml"
+          }
+        ],
+        "Hroznata, son (Herman)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2404.xml"
+          }
+        ],
+        "Hroznata, son, Herman": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2404.xml"
+          }
+        ]
       }
     },
     {
@@ -4369,6 +7947,14 @@
           "person/item_2405.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Dietrich von Burgwerben": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2405.xml"
+          }
+        ]
       }
     },
     {
@@ -4406,6 +7992,38 @@
           "person/item_2406.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Uta of Tarasp": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2406.xml"
+          }
+        ],
+        "Tarasp's Uta": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2406.xml"
+          }
+        ],
+        "Uta": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2406.xml"
+          }
+        ],
+        "Uta (Tarasp)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2406.xml"
+          }
+        ],
+        "Uta, Tarasp": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2406.xml"
+          }
+        ]
       }
     },
     {
@@ -4450,6 +8068,56 @@
           "person/item_2408.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Leopold V of Austria": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2408.xml"
+          }
+        ],
+        "Austria's Leopold": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2408.xml"
+          }
+        ],
+        "Leopold": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2408.xml"
+          }
+        ],
+        "Leopold (Austria)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2408.xml"
+          }
+        ],
+        "Leopold 5": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2408.xml"
+          }
+        ],
+        "Leopold 5 of Austria": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2408.xml"
+          }
+        ],
+        "Leopold V": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2408.xml"
+          }
+        ],
+        "Leopold, Austria": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2408.xml"
+          }
+        ]
       }
     },
     {
@@ -4487,6 +8155,38 @@
           "person/item_2409.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Conrad of Meissen": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2409.xml"
+          }
+        ],
+        "Conrad": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2409.xml"
+          }
+        ],
+        "Conrad (Meissen)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2409.xml"
+          }
+        ],
+        "Conrad, Meissen": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2409.xml"
+          }
+        ],
+        "Meissen's Conrad": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2409.xml"
+          }
+        ]
       }
     },
     {
@@ -4524,6 +8224,38 @@
           "person/item_2410.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Stephen of Perche": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2410.xml"
+          }
+        ],
+        "Perche's Stephen": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2410.xml"
+          }
+        ],
+        "Stephen": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2410.xml"
+          }
+        ],
+        "Stephen (Perche)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2410.xml"
+          }
+        ],
+        "Stephen, Perche": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2410.xml"
+          }
+        ]
       }
     },
     {
@@ -4554,6 +8286,14 @@
           "person/item_2411.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "William Gouet": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2411.xml"
+          }
+        ]
       }
     },
     {
@@ -4591,6 +8331,38 @@
           "person/item_2412.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Seguin of Lastours": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2412.xml"
+          }
+        ],
+        "Lastours's Seguin": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2412.xml"
+          }
+        ],
+        "Seguin": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2412.xml"
+          }
+        ],
+        "Seguin (Lastours)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2412.xml"
+          }
+        ],
+        "Seguin, Lastours": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2412.xml"
+          }
+        ]
       }
     },
     {
@@ -4628,6 +8400,38 @@
           "person/item_2413.xml"
         ],
         "source_system": "omeka-xml"
+      },
+      "variant_provenance": {
+        "Bernard of Dorat": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2413.xml"
+          }
+        ],
+        "Bernard": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2413.xml"
+          }
+        ],
+        "Bernard (Dorat)": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2413.xml"
+          }
+        ],
+        "Bernard, Dorat": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2413.xml"
+          }
+        ],
+        "Dorat's Bernard": [
+          {
+            "system": "omeka-xml",
+            "locator": "person/item_2413.xml"
+          }
+        ]
       }
     },
     {
@@ -4666,6 +8470,44 @@
         "source_files": [],
         "source_system": "manual",
         "note": "added 2026-07-18 per issue #45 (core First-Crusade figures absent from Omeka export); wikidata Q76721"
+      },
+      "variant_provenance": {
+        "Godfrey of Bouillon": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Bouillon's Godfrey": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Duke Godfrey": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Godfrey": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Godfrey (Bouillon)": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Godfrey, Bouillon": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ]
       }
     },
     {
@@ -4713,6 +8555,68 @@
         "source_files": [],
         "source_system": "manual",
         "note": "added 2026-07-18 per issue #45 (core First-Crusade figures absent from Omeka export); wikidata Q333306"
+      },
+      "variant_provenance": {
+        "Robert II of Flanders": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Count Robert of Flanders": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Flanders's Robert": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Robert": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Robert (Flanders)": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Robert 2": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Robert 2 of Flanders": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Robert II": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Robert of Flanders": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Robert, Flanders": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ]
       }
     },
     {
@@ -4751,6 +8655,44 @@
         "source_files": [],
         "source_system": "manual",
         "note": "added 2026-07-18 per issue #45 (core First-Crusade figures absent from Omeka export); wikidata Q266447"
+      },
+      "variant_provenance": {
+        "Ralph of Caen": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Caen's Ralph": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Radulph of Caen": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Ralph": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Ralph (Caen)": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ],
+        "Ralph, Caen": [
+          {
+            "system": "github-issue",
+            "locator": "issue:45"
+          }
+        ]
       }
     }
   ]

--- a/tests/test_authority_provenance.py
+++ b/tests/test_authority_provenance.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+from scripts.backfill_authority_provenance import backfill, validate
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_all_authority_name_forms_have_attributed_provenance():
+    data = json.loads(
+        (ROOT / "scripts" / "outremer_index.json").read_text(encoding="utf-8")
+    )
+    assert not validate(data)
+    assert len(data["persons"]) == 129
+    assert all(record["variant_provenance"] for record in data["persons"])
+
+
+def test_manual_record_provenance_resolves_to_governing_issue():
+    fixture = {
+        "persons": [
+            {
+                "authority_id": "AUTH:T1",
+                "preferred_label": "Example",
+                "variants": ["Exemplum"],
+                "provenance": {
+                    "source_system": "manual",
+                    "source_files": [],
+                    "note": "added per issue #45",
+                },
+            }
+        ]
+    }
+    backfill(fixture)
+    sources = fixture["persons"][0]["variant_provenance"]["Exemplum"]
+    assert sources == [{"system": "github-issue", "locator": "issue:45"}]


### PR DESCRIPTION
## Summary

- add per-name-form provenance for all 129 authority records
- attribute all 614 preferred labels and variants to their Omeka XML source or
  governing manual-curation issue
- add a deterministic backfill/check command
- fail validation when any name form lacks a source system or locator
- preserve the three already verified Wikidata QIDs

## Scope boundary

This PR does not guess Wikidata identities for the other 126 records. Bulk QID
reconciliation is unsafe while #97 shows corrupt authority adjudications; it
remains open work in #94.

## Validation

- 129/129 records validated
- 614/614 name forms attributed
- 116 tests passed
- Ruff passed

Refs #94.
