### PR TITLE
M15.4: pin extraction seed and report evaluation bands

### DIFF
--- a/.github/workflows/Epic5-CI.yml
+++ b/.github/workflows/Epic5-CI.yml
@@ -40,9 +40,9 @@ jobs:
       - run: python -m pytest tests/ -v
       # Offline evaluation over fixture snapshots. Gate is a regression
       # floor below the 2026-07-18 baseline after the #44/#45 gold repair
-      # (combined 0.9155: authority 0.8909, wikidata 1.0); raise it as
-      # linking improves.
-      - run: python -m evaluation.harness --min-agreement 0.85
+      # (combined 0.9155: authority 0.8909, wikidata 1.0). Repeated runs
+      # gate on their lower observed bound; fixture CI is deterministic.
+      - run: python -m evaluation.harness --repeat 3 --min-agreement 0.85
 
   docker:
     name: Docker build

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,10 @@
 # OUTREMER — GPUStack Adaptation Progress
 
 > **Status: Epics 1–8 closed; Epics 9–10 open** (evaluation & linking methodology, #33/#34).
-> Baseline as of 2026-07-18: combined agreement **0.9155** over 71 pairs (authority 0.8909, wikidata 1.0); eval gate ≥ 0.85. 58 tests.
+> Pinned-seed baseline as of 2026-07-18: combined agreement **0.9155** over
+> 71 pairs (authority 0.8909, wikidata 1.0); eval gate ≥ 0.85. Before seed
+> pinning, unchanged code produced an observed combined band of
+> **0.8873–0.9296**. Repeated gates use the lower observed bound.
 
 ## What was done 2026-07-18 (gold repair + repo health)
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ GPUSTACK_API_KEY=your-token-here
 
 # Model names (check GPUStack dashboard for exact names)
 EXTRACTION_MODEL=qwen3-30b-a3b-instruct
+EXTRACTION_SEED=42
 ORCHESTRATOR_MODEL=minimax-m2.7
 QWEN3_VL_MODEL=qwen3-vl-30b-a3b-instruct
 
@@ -160,12 +161,27 @@ Key metric: **linking agreement** — of the pairs scholars reviewed, how
 many does the responsible system's top proposal agree with. Adjudications
 cover two systems, each judged against its own output: the authority-file
 linker (`AUTH:CR…` ids) and Wikidata reconciliation (`wikidata:Q…` ids).
-Baseline 2026-07-18: **combined 0.9155** over 71 pairs (authority 0.8909
-over 55, wikidata 1.0 over 16) — after the #44 gold repair (two
+Pinned-seed baseline 2026-07-18: **combined 0.9155** over 71 pairs
+(authority 0.8909 over 55, wikidata 1.0 over 16). Before seed pinning,
+unchanged code produced an observed combined band of approximately
+**0.8873–0.9296** (63–66 correct of 71); point differences inside that range
+must not be presented as improvements. The pinned baseline follows the #44
+gold repair (two
 wrong-person accepts re-adjudicated to reject) and the #45 authority
 additions (Godfrey of Bouillon, Robert II of Flanders, Ralph of Caen).
 CI fails below 0.85. Residual misses are dominated by extraction drift,
 not linking — see issue #42.
+
+Where a backend does not honour `EXTRACTION_SEED`, generate repeated live
+outputs and evaluate them as a band:
+
+```bash
+python -m evaluation.harness --live --repeat 5 \
+  --repeat-command "python scripts/run_pipeline.py"
+```
+
+Repeated gates use the lowest observed agreement, not the mean, so sampling
+variance cannot make a regression appear to pass.
 
 ---
 

--- a/evaluation/harness.py
+++ b/evaluation/harness.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
+import subprocess
 import sys
 from pathlib import Path
 
@@ -172,6 +174,17 @@ def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     ap.add_argument("--fixtures", default=str(FIXTURES_DIR))
     ap.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help="evaluate N samples and report mean plus observed range",
+    )
+    ap.add_argument(
+        "--repeat-command",
+        default=None,
+        help="command to refresh live predictions before every repeated sample",
+    )
+    ap.add_argument(
         "--live",
         action="store_true",
         help="evaluate current site/data output instead of fixture snapshots",
@@ -207,24 +220,51 @@ def main(argv: list[str] | None = None) -> int:
         print(f"No fixtures found in {args.fixtures}", file=sys.stderr)
         return 2
 
-    doc_results: dict[str, dict] = {}
-    for f in fixture_files:
-        fixture = json.loads(f.read_text())
-        doc_results[fixture["doc_id"]] = evaluate_fixture(
-            fixture, live=args.live, relink=args.relink
-        )
+    if args.repeat < 1:
+        ap.error("--repeat must be at least 1")
+    if args.repeat_command and not args.live:
+        ap.error("--repeat-command requires --live")
+
+    samples: list[dict] = []
+    for sample_number in range(1, args.repeat + 1):
+        if args.repeat_command:
+            subprocess.run(shlex.split(args.repeat_command), check=True)
+        doc_results: dict[str, dict] = {}
+        for f in fixture_files:
+            fixture = json.loads(f.read_text())
+            doc_results[fixture["doc_id"]] = evaluate_fixture(
+                fixture, live=args.live, relink=args.relink
+            )
+
+        sample_totals: dict[str, list[int]] = {
+            "linking": [0, 0], "wikidata": [0, 0]
+        }
+        for res in doc_results.values():
+            for segment in ("linking", "wikidata"):
+                result = res.get(segment)
+                if result:
+                    sample_totals[segment][0] += result["reviewed_pairs"]
+                    sample_totals[segment][1] += (
+                        result["accept_hit"] + result["reject_avoided"]
+                    )
+        sample_pairs = sum(total for total, _ in sample_totals.values())
+        sample_good = sum(good for _, good in sample_totals.values())
+        samples.append({
+            "sample": sample_number,
+            "documents": doc_results,
+            "segments": sample_totals,
+            "aggregate_agreement": (
+                sample_good / sample_pairs if sample_pairs else None
+            ),
+        })
+
+    doc_results = samples[-1]["documents"]
 
     print(format_report(doc_results))
 
     # Aggregate agreement across documents (pair-weighted), per system and
     # combined — each adjudicated pair judged against the system that made it
-    seg_totals: dict[str, list[int]] = {"linking": [0, 0], "wikidata": [0, 0]}
-    for res in doc_results.values():
-        for seg in ("linking", "wikidata"):
-            r = res.get(seg)
-            if r:
-                seg_totals[seg][0] += r["reviewed_pairs"]
-                seg_totals[seg][1] += r["accept_hit"] + r["reject_avoided"]
+    seg_totals = samples[-1]["segments"]
 
     total_pairs = sum(t for t, _ in seg_totals.values())
     good = sum(g for _, g in seg_totals.values())
@@ -238,11 +278,35 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{'combined agreement':>24}: {aggregate:.4f} over {total_pairs} reviewed pairs")
     else:
         aggregate = None
+    observed = [
+        sample["aggregate_agreement"]
+        for sample in samples
+        if sample["aggregate_agreement"] is not None
+    ]
+    uncertainty = None
+    if observed:
+        uncertainty = {
+            "samples": len(observed),
+            "mean": sum(observed) / len(observed),
+            "min": min(observed),
+            "max": max(observed),
+        }
+        if args.repeat > 1:
+            print(
+                f"{'observed band':>24}: mean {uncertainty['mean']:.4f}; "
+                f"range {uncertainty['min']:.4f}–{uncertainty['max']:.4f} "
+                f"over {uncertainty['samples']} samples"
+            )
 
     if args.output:
         Path(args.output).write_text(
             json.dumps(
-                {"documents": doc_results, "aggregate_agreement": aggregate},
+                {
+                    "documents": doc_results,
+                    "aggregate_agreement": aggregate,
+                    "uncertainty": uncertainty,
+                    "samples": samples if args.repeat > 1 else None,
+                },
                 indent=2,
                 ensure_ascii=False,
             )
@@ -253,11 +317,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if (
         args.min_agreement is not None
-        and aggregate is not None
-        and aggregate < args.min_agreement
+        and observed
+        and min(observed) < args.min_agreement
     ):
         print(
-            f"FAIL: aggregate agreement {aggregate:.4f} < --min-agreement {args.min_agreement}",
+            f"FAIL: lower observed agreement {min(observed):.4f} "
+            f"< --min-agreement {args.min_agreement}",
             file=sys.stderr,
         )
         return 1

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -11,6 +11,7 @@ Env vars (set in .env.gpustack, git-ignored):
     ORCHESTRATOR_MODEL   - model for orchestration (default minimax-m2.7)
     QWEN3_VL_MODEL       - vision model for document OCR (default qwen3-vl-30b-a3b-instruct)
     OCR_ENGINE           - qwen3-vl | mistral (default qwen3-vl)
+    EXTRACTION_SEED      - fixed chat-completion seed (default 42)
 """
 from __future__ import annotations
 
@@ -54,6 +55,7 @@ GPUSTACK_TIMEOUT   = int(_get("GPUSTACK_TIMEOUT", "120"))
 EXTRACTION_MODEL   = _get("EXTRACTION_MODEL",   "qwen3-30b-a3b-instruct")
 ORCHESTRATOR_MODEL = _get("ORCHESTRATOR_MODEL", "minimax-m2.7")
 QWEN3_VL_MODEL     = _get("QWEN3_VL_MODEL",     "qwen3-vl-30b-a3b-instruct")
+EXTRACTION_SEED    = int(_get("EXTRACTION_SEED", "42"))
 
 # OCR
 # "qwen3-vl" - GPUStack Qwen3 VL (default); falls back to Mistral if empty

--- a/scripts/extract_persons.py
+++ b/scripts/extract_persons.py
@@ -1108,7 +1108,7 @@ def extract_persons_and_metadata(
     feedback_store = _load_entity_feedback(feedback_path)
     feedback_terms = _feedback_terms_for_prompt(feedback_store)
 
-    from config import EXTRACTION_MODEL, GPUSTACK_BASE_URL
+    from config import EXTRACTION_MODEL, EXTRACTION_SEED, GPUSTACK_BASE_URL
 
     if GPUSTACK_BASE_URL:
         result = _extract_gpustack(
@@ -1117,7 +1117,11 @@ def extract_persons_and_metadata(
             language=language,
             blocked_terms=feedback_terms,
         )
-        result["engine"] = {"provider": "gpustack", "model": EXTRACTION_MODEL}
+        result["engine"] = {
+            "provider": "gpustack",
+            "model": EXTRACTION_MODEL,
+            "seed": EXTRACTION_SEED,
+        }
     else:
         result = _extract_fallback(text)
         if use_llm_metadata:

--- a/scripts/llm_client.py
+++ b/scripts/llm_client.py
@@ -20,6 +20,7 @@ import openai
 
 from config import (
     EXTRACTION_MODEL,
+    EXTRACTION_SEED,
     GPUSTACK_API_KEY,
     GPUSTACK_BASE_URL,
     GPUSTACK_TIMEOUT,
@@ -93,6 +94,7 @@ def generate(
     if system:
         messages.append({"role": "system", "content": system})
     messages.append({"role": "user", "content": prompt})
+    kwargs.setdefault("seed", EXTRACTION_SEED)
 
     client = get_client()
     resp = client.chat.completions.create(

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -33,7 +33,7 @@ from linker import build_authority_lookup, link_voyagers_to_outremer, normalise
 from llm_client import generate as _llm_generate
 from validate_decisions import validate_decisions_file
 
-from config import EXTRACTION_MODEL, GPUSTACK_BASE_URL, OCR_ENGINE
+from config import EXTRACTION_MODEL, EXTRACTION_SEED, GPUSTACK_BASE_URL, OCR_ENGINE
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -51,6 +51,7 @@ def _write_run_report(
     docs_failed: int,
     total_persons: int,
     extraction_model: str,
+    extraction_seed: int,
     ocr_engine: str,
     failures: list[dict],
     feedback_applied: dict[str, int] | None = None,
@@ -66,6 +67,7 @@ def _write_run_report(
         "total_persons": total_persons,
         "llm_provider": llm_provider,
         "extraction_model": extraction_model,
+        "extraction_seed": extraction_seed,
         "ocr_engine": ocr_engine,
         "failures": failures,
     }
@@ -670,6 +672,7 @@ def main() -> int:
         docs_failed=len(errors),
         total_persons=total_persons,
         extraction_model=EXTRACTION_MODEL,
+        extraction_seed=EXTRACTION_SEED,
         ocr_engine=OCR_ENGINE,
         failures=[{"file": str(p), "error": str(e)} for p, e in errors],
         feedback_applied=feedback_stats,

--- a/tests/test_evaluation_repeat.py
+++ b/tests/test_evaluation_repeat.py
@@ -1,0 +1,45 @@
+import json
+
+from evaluation import harness
+
+
+def test_repeat_report_contains_mean_and_observed_range(tmp_path):
+    output = tmp_path / "repeat.json"
+    assert harness.main(["--repeat", "3", "--output", str(output)]) == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["uncertainty"]["samples"] == 3
+    assert report["uncertainty"]["min"] == report["uncertainty"]["max"]
+    assert len(report["samples"]) == 3
+
+
+def test_repeat_gate_uses_lower_observed_bound(monkeypatch, tmp_path):
+    values = iter([0.90, 0.80])
+    original = harness.evaluate_fixture
+
+    def variable_sample(fixture, **kwargs):
+        result = original(fixture, **kwargs)
+        if "linking" in result:
+            agreement = next(values)
+            result["linking"] = {
+                "reviewed_pairs": 10,
+                "accept_hit": round(agreement * 10),
+                "accept_miss": 10 - round(agreement * 10),
+                "reject_hit": 0,
+                "reject_avoided": 0,
+                "agreement": agreement,
+            }
+        return result
+
+    fixture = {
+        "doc_id": "sample",
+        "mode": "adjudicated",
+        "accepted": [["Name", "AUTH:1"]],
+        "predictions": {"persons": ["Name"], "links": []},
+    }
+    (tmp_path / "sample.json").write_text(json.dumps(fixture), encoding="utf-8")
+    monkeypatch.setattr(harness, "evaluate_fixture", variable_sample)
+    assert harness.main([
+        "--fixtures", str(tmp_path),
+        "--repeat", "2",
+        "--min-agreement", "0.85",
+    ]) == 1

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -43,6 +43,7 @@ def test_generate_defaults_to_extraction_model(fake_client):
     generate("p")
     kwargs = fake_client.chat.completions.create.call_args.kwargs
     assert kwargs["model"] == llm_client.EXTRACTION_MODEL
+    assert kwargs["seed"] == llm_client.EXTRACTION_SEED
 
     generate("p", model="other-model")
     kwargs = fake_client.chat.completions.create.call_args.kwargs


### PR DESCRIPTION
## Summary

- pass a fixed `EXTRACTION_SEED` (default 42) to GPUStack completions
- record the seed in extraction provenance and pipeline run reports
- add `evaluation.harness --repeat N`
- optionally refresh live predictions before each sample with
  `--repeat-command`
- report mean plus observed min/max instead of treating one draw as truth
- gate repeated evaluations on the lower observed bound
- document the historical pre-seed band and pinned-seed baseline
- run deterministic fixture CI three times to exercise lower-bound gating

## Validation

- 116 tests passed
- Ruff passed

Closes #78.
