### PR TITLE
M18.2: route GPUStack models by role

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,18 @@ Copy `.env.gpustack` template (or create manually):
 GPUSTACK_BASE_URL=https://gpustack.unibe.ch/v1
 GPUSTACK_API_KEY=your-token-here
 
-# Model names (check GPUStack dashboard for exact names)
-EXTRACTION_MODEL=qwen3-30b-a3b-instruct
-ORCHESTRATOR_MODEL=minimax-m2.7
-QWEN3_VL_MODEL=qwen3-vl-30b-a3b-instruct
+# Role-based model routing (check GPUStack dashboard for exact names)
+GPUSTACK_MODEL_VISION=qwen3-vl-30b-a3b-instruct
+GPUSTACK_MODEL_TEXT=gpt-oss-120b
+GPUSTACK_MODEL_ORCHESTRATOR=minimax-m2.7
 
 # OCR engine: qwen3-vl (GPUStack, default) or mistral (legacy fallback)
 OCR_ENGINE=qwen3-vl
 ```
 
 `.env.gpustack` is git-ignored. Without it, `config.py` uses sensible defaults (tei endpoint, no API key required for public models).
+The former `QWEN3_VL_MODEL`, `EXTRACTION_MODEL`, and `ORCHESTRATOR_MODEL`
+variables remain supported as deprecated aliases.
 
 ---
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -7,9 +7,11 @@ Env vars (set in .env.gpustack, git-ignored):
     GPUSTACK_BASE_URL    - defaults to https://gpustack.unibe.ch/v1
     GPUSTACK_API_KEY     - API key for GPUStack authentication
     GPUSTACK_TIMEOUT     - request timeout in seconds (default 120)
-    EXTRACTION_MODEL     - model for person extraction (default qwen3-30b-a3b-instruct)
-    ORCHESTRATOR_MODEL   - model for orchestration (default minimax-m2.7)
-    QWEN3_VL_MODEL       - vision model for document OCR (default qwen3-vl-30b-a3b-instruct)
+    GPUSTACK_MODEL_TEXT          - text extraction/metadata model (default gpt-oss-120b)
+    GPUSTACK_MODEL_ORCHESTRATOR  - orchestration model (default minimax-m2.7)
+    GPUSTACK_MODEL_VISION        - document OCR model (default qwen3-vl-30b-a3b-instruct)
+    EXTRACTION_MODEL, ORCHESTRATOR_MODEL, and QWEN3_VL_MODEL remain supported
+        as deprecated aliases.
     OCR_ENGINE           - qwen3-vl | mistral (default qwen3-vl)
 """
 from __future__ import annotations
@@ -50,10 +52,34 @@ GPUSTACK_BASE_URL  = _get("GPUSTACK_BASE_URL",  "https://gpustack.unibe.ch/v1")
 GPUSTACK_API_KEY   = os.environ.get("GPUSTACK_API_KEY", "")
 GPUSTACK_TIMEOUT   = int(_get("GPUSTACK_TIMEOUT", "120"))
 
-# Model names - must match exactly how models are registered in GPUStack
-EXTRACTION_MODEL   = _get("EXTRACTION_MODEL",   "qwen3-30b-a3b-instruct")
-ORCHESTRATOR_MODEL = _get("ORCHESTRATOR_MODEL", "minimax-m2.7")
-QWEN3_VL_MODEL     = _get("QWEN3_VL_MODEL",     "qwen3-vl-30b-a3b-instruct")
+def resolve_model_roles(environ: os._Environ[str] | dict[str, str]) -> dict[str, str]:
+    """Resolve role-based models, with deprecated environment aliases."""
+    return {
+        "VISION": environ.get(
+            "GPUSTACK_MODEL_VISION",
+            environ.get("QWEN3_VL_MODEL", "qwen3-vl-30b-a3b-instruct"),
+        ),
+        "TEXT": environ.get(
+            "GPUSTACK_MODEL_TEXT",
+            environ.get("EXTRACTION_MODEL", "gpt-oss-120b"),
+        ),
+        "ORCH": environ.get(
+            "GPUSTACK_MODEL_ORCHESTRATOR",
+            environ.get("ORCHESTRATOR_MODEL", "minimax-m2.7"),
+        ),
+    }
+
+
+# Model names must match exactly how models are registered in GPUStack.
+MODEL_ROLES = resolve_model_roles(os.environ)
+GPUSTACK_MODEL_VISION = MODEL_ROLES["VISION"]
+GPUSTACK_MODEL_TEXT = MODEL_ROLES["TEXT"]
+GPUSTACK_MODEL_ORCHESTRATOR = MODEL_ROLES["ORCH"]
+
+# Deprecated Python aliases retained for downstream compatibility.
+QWEN3_VL_MODEL = GPUSTACK_MODEL_VISION
+EXTRACTION_MODEL = GPUSTACK_MODEL_TEXT
+ORCHESTRATOR_MODEL = GPUSTACK_MODEL_ORCHESTRATOR
 
 # OCR
 # "qwen3-vl" - GPUStack Qwen3 VL (default); falls back to Mistral if empty

--- a/scripts/extract_persons.py
+++ b/scripts/extract_persons.py
@@ -50,8 +50,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-# GPUStack LLM client
 from llm_client import generate as _llm_generate
+
+# GPUStack LLM client
+from config import GPUSTACK_MODEL_TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +61,6 @@ logger = logging.getLogger(__name__)
 # Constants
 # ──────────────────────────────────────────────
 
-# GPUStack model — see scripts/config.py / .env.gpustack
-_EXTRACTION_MODEL = "qwen3-30b-a3b-instruct"  # from config.EXTRACTION_MODEL at runtime
 _CHUNK_SIZE = 5_500   # chunk size for GPUStack extraction
 _CHUNK_OVERLAP = 800
 
@@ -998,7 +998,7 @@ def _extract_gpustack_chunk(
     prompt = _build_prompt(language, blocked_terms=blocked_terms) + clean_chunk
     raw_text = _llm_generate(
         prompt,
-        model=_EXTRACTION_MODEL,
+        model=GPUSTACK_MODEL_TEXT,
         max_tokens=4096,
         temperature=0.1,
     )
@@ -1108,7 +1108,7 @@ def extract_persons_and_metadata(
     feedback_store = _load_entity_feedback(feedback_path)
     feedback_terms = _feedback_terms_for_prompt(feedback_store)
 
-    from config import EXTRACTION_MODEL, GPUSTACK_BASE_URL
+    from config import GPUSTACK_BASE_URL
 
     if GPUSTACK_BASE_URL:
         result = _extract_gpustack(
@@ -1117,7 +1117,11 @@ def extract_persons_and_metadata(
             language=language,
             blocked_terms=feedback_terms,
         )
-        result["engine"] = {"provider": "gpustack", "model": EXTRACTION_MODEL}
+        result["engine"] = {
+            "provider": "gpustack",
+            "role": "TEXT",
+            "model": GPUSTACK_MODEL_TEXT,
+        }
     else:
         result = _extract_fallback(text)
         if use_llm_metadata:

--- a/scripts/llm_client.py
+++ b/scripts/llm_client.py
@@ -19,9 +19,9 @@ from typing import Any
 import openai
 
 from config import (
-    EXTRACTION_MODEL,
     GPUSTACK_API_KEY,
     GPUSTACK_BASE_URL,
+    GPUSTACK_MODEL_TEXT,
     GPUSTACK_TIMEOUT,
 )
 
@@ -83,7 +83,7 @@ def generate(
     Args:
         prompt   — user message
         system   — optional system prompt
-        model    — override EXTRACTION_MODEL (None = use config default)
+        model    — override GPUSTACK_MODEL_TEXT (None = use config default)
         **kwargs — passed through to the API (temperature, max_tokens, …)
 
     Returns:
@@ -94,9 +94,11 @@ def generate(
         messages.append({"role": "system", "content": system})
     messages.append({"role": "user", "content": prompt})
 
+    # Reasoning text models need enough room for hidden reasoning plus output.
+    kwargs.setdefault("max_tokens", 4096)
     client = get_client()
     resp = client.chat.completions.create(
-        model=model or EXTRACTION_MODEL,
+        model=model or GPUSTACK_MODEL_TEXT,
         messages=messages,
         **kwargs,
     )

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -33,7 +33,13 @@ from linker import build_authority_lookup, link_voyagers_to_outremer, normalise
 from llm_client import generate as _llm_generate
 from validate_decisions import validate_decisions_file
 
-from config import EXTRACTION_MODEL, GPUSTACK_BASE_URL, OCR_ENGINE
+from config import (
+    GPUSTACK_BASE_URL,
+    GPUSTACK_MODEL_TEXT,
+    GPUSTACK_MODEL_VISION,
+    MODEL_ROLES,
+    OCR_ENGINE,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -51,6 +57,7 @@ def _write_run_report(
     docs_failed: int,
     total_persons: int,
     extraction_model: str,
+    model_roles: dict[str, str],
     ocr_engine: str,
     failures: list[dict],
     feedback_applied: dict[str, int] | None = None,
@@ -66,6 +73,7 @@ def _write_run_report(
         "total_persons": total_persons,
         "llm_provider": llm_provider,
         "extraction_model": extraction_model,
+        "model_roles": model_roles,
         "ocr_engine": ocr_engine,
         "failures": failures,
     }
@@ -156,8 +164,6 @@ def _qwen3vl_ocr(path: Path) -> str:
     """GPUStack Qwen3 VL 30B for primary document OCR."""
     import base64
 
-    from config import QWEN3_VL_MODEL
-
     b64 = base64.b64encode(path.read_bytes()).decode()
     prompt = (
         "You are an OCR system. Given an image of a document page, transcribe ALL text "
@@ -168,7 +174,7 @@ def _qwen3vl_ocr(path: Path) -> str:
     try:
         text = _llm_generate(
             prompt,
-            model=QWEN3_VL_MODEL,
+            model=GPUSTACK_MODEL_VISION,
             max_tokens=8192,
             temperature=0.0,
         )
@@ -669,7 +675,8 @@ def main() -> int:
         docs_ok=len(inputs) - len(errors),
         docs_failed=len(errors),
         total_persons=total_persons,
-        extraction_model=EXTRACTION_MODEL,
+        extraction_model=GPUSTACK_MODEL_TEXT,
+        model_roles=MODEL_ROLES,
         ocr_engine=OCR_ENGINE,
         failures=[{"file": str(p), "error": str(e)} for p, e in errors],
         feedback_applied=feedback_stats,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+"""Tests for role-based GPUStack model configuration."""
+
+from config import resolve_model_roles
+
+
+def test_role_model_defaults():
+    assert resolve_model_roles({}) == {
+        "VISION": "qwen3-vl-30b-a3b-instruct",
+        "TEXT": "gpt-oss-120b",
+        "ORCH": "minimax-m2.7",
+    }
+
+
+def test_deprecated_model_aliases_are_supported():
+    roles = resolve_model_roles(
+        {
+            "QWEN3_VL_MODEL": "legacy-vision",
+            "EXTRACTION_MODEL": "legacy-text",
+            "ORCHESTRATOR_MODEL": "legacy-orchestrator",
+        }
+    )
+    assert roles == {
+        "VISION": "legacy-vision",
+        "TEXT": "legacy-text",
+        "ORCH": "legacy-orchestrator",
+    }
+
+
+def test_role_keys_take_precedence_over_deprecated_aliases():
+    roles = resolve_model_roles(
+        {
+            "GPUSTACK_MODEL_VISION": "role-vision",
+            "GPUSTACK_MODEL_TEXT": "role-text",
+            "GPUSTACK_MODEL_ORCHESTRATOR": "role-orchestrator",
+            "QWEN3_VL_MODEL": "legacy-vision",
+            "EXTRACTION_MODEL": "legacy-text",
+            "ORCHESTRATOR_MODEL": "legacy-orchestrator",
+        }
+    )
+    assert roles == {
+        "VISION": "role-vision",
+        "TEXT": "role-text",
+        "ORCH": "role-orchestrator",
+    }

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -39,14 +39,16 @@ def test_generate_builds_messages_with_system(fake_client):
     ]
 
 
-def test_generate_defaults_to_extraction_model(fake_client):
+def test_generate_defaults_to_text_model_and_token_budget(fake_client):
     generate("p")
     kwargs = fake_client.chat.completions.create.call_args.kwargs
-    assert kwargs["model"] == llm_client.EXTRACTION_MODEL
+    assert kwargs["model"] == llm_client.GPUSTACK_MODEL_TEXT
+    assert kwargs["max_tokens"] == 4096
 
-    generate("p", model="other-model")
+    generate("p", model="other-model", max_tokens=512)
     kwargs = fake_client.chat.completions.create.call_args.kwargs
     assert kwargs["model"] == "other-model"
+    assert kwargs["max_tokens"] == 512
 
 
 def test_generate_none_content_returns_empty_string(fake_client):

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -1,0 +1,29 @@
+"""Tests for pipeline run-report provenance."""
+
+import json
+
+from run_pipeline import _write_run_report
+
+
+def test_run_report_records_resolved_model_roles(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    roles = {
+        "VISION": "vision-model",
+        "TEXT": "text-model",
+        "ORCH": "orchestrator-model",
+    }
+
+    _write_run_report(
+        run_at="2026-07-30T09:00:00+00:00",
+        docs_total=1,
+        docs_ok=1,
+        docs_failed=0,
+        total_persons=2,
+        extraction_model=roles["TEXT"],
+        model_roles=roles,
+        ocr_engine="qwen3-vl",
+        failures=[],
+    )
+
+    report = json.loads((tmp_path / "data/staging/run_report.json").read_text())
+    assert report["model_roles"] == roles


### PR DESCRIPTION
Closes #88

## Summary
- add VISION, TEXT, and ORCH GPUStack model roles with documented defaults
- preserve the former model environment variables and Python constants as deprecated aliases
- route OCR through VISION and extraction/metadata through TEXT, removing a hard-coded extraction model
- reserve 4096 tokens by default for text/reasoning calls
- record the resolved role-to-model mapping in every run report

## Validation
- `ruff check` on all changed Python files
- `python -m pytest tests/ -q` (118 passed)