### PR TITLE
M15.2: enforce closest-reading evaluation protocol

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,37 @@
+# Evaluation methodology
+
+## Recognition selections are closest-reading evidence
+
+A Human-in-the-Loop recognition choice means only that the scholar selected
+the closest acceptable reading from the candidates the pipeline offered. It
+is not an independently transcribed reference and must not be described as
+ground truth or gold.
+
+Selection-derived recognition evaluation therefore reports:
+
+- **Coverage:** whether the candidate pool offered an acceptable reading.
+- **Selection agreement:** whether the automatic choice matched the human
+  choice among covered events.
+- **Selection regret:** candidate-to-candidate CER between the automatic and
+  human choices. This is a distance within the offered pool, not accuracy.
+- **Relative engine preference:** pairwise human choices may later support
+  routing priors by script, language, or century.
+
+If every candidate contains the same error, selecting one does not make that
+error correct. Absolute CER or WER requires a separately produced,
+independent scholarly reference transcription. It must remain distinct from
+selection data in both storage and terminology.
+
+Recognition selection events use this shape:
+
+```json
+{
+  "candidates": ["offered reading A", "offered reading B"],
+  "automatic_selection": "offered reading A",
+  "human_selection": "offered reading B"
+}
+```
+
+`human_selection: null` records that no offered reading was usable. The
+evaluation code rejects selection payloads whose fields make truth claims
+using the forbidden names `ground_truth` or `gold`.

--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -14,5 +14,6 @@ from evaluation.metrics import (  # noqa: F401
     cer,
     extraction_prf,
     linking_agreement,
+    selection_metrics,
     wer,
 )

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -183,6 +183,71 @@ def candidate_distance(candidates: list[str], **normalisation: bool) -> dict:
     }
 
 
+_FORBIDDEN_SELECTION_FIELDS = {"ground_truth", "gold"}
+
+
+def validate_selection_event(event: dict) -> None:
+    """Reject misleading selection-data names and malformed candidate choices."""
+    stack: list[object] = [event]
+    while stack:
+        value = stack.pop()
+        if isinstance(value, dict):
+            forbidden = {
+                str(key).casefold() for key in value
+            } & _FORBIDDEN_SELECTION_FIELDS
+            if forbidden:
+                names = ", ".join(sorted(forbidden))
+                raise ValueError(
+                    f"selection-derived data cannot use truth-claim field(s): {names}"
+                )
+            stack.extend(value.values())
+        elif isinstance(value, list):
+            stack.extend(value)
+
+    candidates = event.get("candidates")
+    if not isinstance(candidates, list) or not all(
+        isinstance(candidate, str) for candidate in candidates
+    ):
+        raise ValueError("selection event candidates must be a list of strings")
+    for field in ("automatic_selection", "human_selection"):
+        selection = event.get(field)
+        if selection is not None and selection not in candidates:
+            raise ValueError(f"{field} must be one of the offered candidates or null")
+
+
+def selection_metrics(events: list[dict]) -> dict:
+    """Measure candidate coverage, automatic selection agreement, and regret.
+
+    A non-null ``human_selection`` means the offered pool contained an
+    acceptable reading. It is the closest acceptable option in that bounded
+    pool, not an independent reference transcription.
+    """
+    for event in events:
+        validate_selection_event(event)
+
+    covered = [event for event in events if event.get("human_selection") is not None]
+    comparable = [
+        event for event in covered if event.get("automatic_selection") is not None
+    ]
+    matches = sum(
+        event["automatic_selection"] == event["human_selection"]
+        for event in comparable
+    )
+    regrets = [
+        cer(event["human_selection"], event["automatic_selection"])
+        for event in comparable
+    ]
+    return {
+        "events": len(events),
+        "covered": len(covered),
+        "coverage": len(covered) / len(events) if events else 0.0,
+        "comparable_selections": len(comparable),
+        "automatic_matches": matches,
+        "selection_agreement": matches / len(comparable) if comparable else 0.0,
+        "mean_regret_cer": sum(regrets) / len(regrets) if regrets else 0.0,
+    }
+
+
 def _fold_particles(norm: str) -> str:
     tokens = [t for t in norm.split() if t not in _PARTICLES]
     if len(tokens) < 2:

--- a/tests/test_recognition_selection_metrics.py
+++ b/tests/test_recognition_selection_metrics.py
@@ -1,0 +1,73 @@
+"""Closest-reading evaluation tests for selection-derived recognition data."""
+
+import pytest
+
+from evaluation.metrics import selection_metrics, validate_selection_event
+
+
+def test_selection_metrics_report_coverage_agreement_and_regret():
+    events = [
+        {
+            "candidates": ["deus vult", "deus uult"],
+            "automatic_selection": "deus vult",
+            "human_selection": "deus vult",
+        },
+        {
+            "candidates": ["rex francorum", "rex francerum"],
+            "automatic_selection": "rex francerum",
+            "human_selection": "rex francorum",
+        },
+        {
+            "candidates": ["unusable", "also unusable"],
+            "automatic_selection": "unusable",
+            "human_selection": None,
+        },
+    ]
+
+    result = selection_metrics(events)
+    assert result["events"] == 3
+    assert result["covered"] == 2
+    assert result["coverage"] == 2 / 3
+    assert result["comparable_selections"] == 2
+    assert result["automatic_matches"] == 1
+    assert result["selection_agreement"] == 0.5
+    assert result["mean_regret_cer"] == pytest.approx(1 / 26)
+
+
+def test_no_automatic_choice_is_excluded_from_selection_comparison():
+    result = selection_metrics(
+        [
+            {
+                "candidates": ["acceptable"],
+                "automatic_selection": None,
+                "human_selection": "acceptable",
+            }
+        ]
+    )
+    assert result["coverage"] == 1.0
+    assert result["comparable_selections"] == 0
+    assert result["selection_agreement"] == 0.0
+
+
+@pytest.mark.parametrize("field", ["ground_truth", "gold", "GROUND_TRUTH"])
+def test_selection_payload_rejects_truth_claim_field_names(field):
+    with pytest.raises(ValueError, match="truth-claim"):
+        validate_selection_event(
+            {
+                "candidates": ["a"],
+                "automatic_selection": "a",
+                "human_selection": "a",
+                "metadata": {field: "a"},
+            }
+        )
+
+
+def test_selection_must_refer_to_an_offered_candidate():
+    with pytest.raises(ValueError, match="offered candidates"):
+        validate_selection_event(
+            {
+                "candidates": ["offered"],
+                "automatic_selection": "invented",
+                "human_selection": "offered",
+            }
+        )


### PR DESCRIPTION
Closes #76

Depends on #105.

## Summary
- document why Human-in-the-Loop choices are bounded closest-reading evidence, not independent reference transcriptions
- report candidate coverage, automatic-selection agreement, and candidate-to-candidate regret
- reject selection payload fields named `ground_truth` or `gold`
- validate that recorded selections came from the offered candidate pool

## Validation
- changed-file Ruff checks passed
- `python -m pytest tests/ -q` (124 passed)