### PR TITLE
M14.1: add ATR gateway client

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Copy `.env.gpustack` template (or create manually):
 GPUSTACK_BASE_URL=https://gpustack.unibe.ch/v1
 GPUSTACK_API_KEY=your-token-here
 
+# Optional local ATR recognition gateway
+ATR_GATEWAY_URL=http://localhost:8200
+ATR_API_KEY=your-gateway-token
+ATR_HTTP_TIMEOUT=300
+
 # Model names (check GPUStack dashboard for exact names)
 EXTRACTION_MODEL=qwen3-30b-a3b-instruct
 ORCHESTRATOR_MODEL=minimax-m2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # LLM (all inference via GPUStack, OpenAI-compatible API)
 openai>=1.0
+httpx>=0.28
 
 # Core pipeline
 rapidfuzz>=3.0

--- a/scripts/atr_client.py
+++ b/scripts/atr_client.py
@@ -1,0 +1,183 @@
+"""Client for the serving-atr-inference recognition gateway.
+
+The gateway exposes health/model discovery plus segmentation and recognition:
+``GET /health``, ``GET /models``, and ``POST /segment``, ``/recognize``,
+``/ocr``. Every authenticated request carries ``X-API-Key``.
+
+``/ocr`` auto-segments page images and accepts kraken and TrOCR engines.
+The page-level ``party`` engine must use ``/recognize``.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from config import ATR_API_KEY, ATR_GATEWAY_URL, ATR_HTTP_TIMEOUT
+
+
+class AtrClientError(RuntimeError):
+    """Raised when the ATR gateway is unreachable or rejects a request."""
+
+
+@dataclass(frozen=True)
+class AtrResult:
+    """Attributed recognition result returned by the ATR gateway."""
+
+    text: str
+    confidence: float
+    model: str
+    engine: str
+    service_version: str = "?"
+
+
+class AtrClient:
+    """Thin synchronous client for serving-atr-inference."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        *,
+        api_key: str | None = None,
+        timeout: float | None = None,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self.base_url = (base_url if base_url is not None else ATR_GATEWAY_URL).rstrip("/")
+        self.api_key = ATR_API_KEY if api_key is None else api_key
+        self.timeout = ATR_HTTP_TIMEOUT if timeout is None else timeout
+        self._client = http_client
+        self._owns_client = http_client is None
+
+    def __enter__(self) -> AtrClient:
+        self._get_client()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the internally owned HTTP session, if one was created."""
+        if self._client is not None and self._owns_client:
+            self._client.close()
+            self._client = None
+
+    def health_check(self) -> dict[str, Any]:
+        """Return gateway health and engine availability."""
+        return self._request("GET", "/health").json()
+
+    def list_models(self) -> list[dict[str, Any]]:
+        """Return the gateway's attributed model registry."""
+        models = self._request("GET", "/models").json().get("models", [])
+        return models if isinstance(models, list) else []
+
+    def segment(
+        self,
+        image: Path | bytes | io.BytesIO,
+        *,
+        seg_mode: str = "baseline",
+    ) -> dict[str, Any]:
+        """Segment a page without recognizing its text."""
+        response = self._request(
+            "POST",
+            "/segment",
+            files=self._image_part(image),
+            data={"seg_mode": seg_mode},
+        )
+        return response.json()
+
+    def recognize(
+        self,
+        image: Path | bytes | io.BytesIO,
+        *,
+        model: str,
+        engine: str = "party",
+    ) -> AtrResult:
+        """Recognize a page through ``/recognize`` (required for party)."""
+        response = self._request(
+            "POST",
+            "/recognize",
+            files=self._image_part(image),
+            data={"model": model},
+        )
+        return self._result(response, model=model, engine=engine)
+
+    def transcribe(
+        self,
+        image: Path | bytes | io.BytesIO,
+        *,
+        model: str,
+        engine: str = "kraken",
+        seg_mode: str = "baseline",
+    ) -> AtrResult:
+        """Recognize a page, dispatching party to its required endpoint."""
+        if engine.casefold() == "party":
+            return self.recognize(image, model=model, engine=engine)
+        if engine.casefold() not in {"kraken", "trocr"}:
+            raise ValueError("ATR /ocr supports only kraken and trocr engines")
+        response = self._request(
+            "POST",
+            "/ocr",
+            files=self._image_part(image),
+            data={"model": model, "seg_mode": seg_mode},
+        )
+        return self._result(response, model=model, engine=engine)
+
+    def _get_client(self) -> httpx.Client:
+        if self._client is None:
+            if not self.base_url:
+                raise AtrClientError(
+                    "ATR gateway URL is not configured; set ATR_GATEWAY_URL"
+                )
+            headers = {"X-API-Key": self.api_key} if self.api_key else {}
+            self._client = httpx.Client(
+                base_url=self.base_url,
+                headers=headers,
+                timeout=self.timeout,
+                follow_redirects=True,
+            )
+        return self._client
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        try:
+            response = self._get_client().request(method, path, **kwargs)
+        except httpx.RequestError as exc:
+            raise AtrClientError(
+                f"ATR gateway unreachable at {self.base_url}{path}: {exc}"
+            ) from exc
+        if response.status_code >= 400:
+            raise AtrClientError(
+                f"ATR gateway returned {response.status_code} at {path}: "
+                f"{response.text[:400]}"
+            )
+        return response
+
+    @staticmethod
+    def _image_part(
+        image: Path | bytes | io.BytesIO,
+    ) -> dict[str, tuple[str, bytes, str]]:
+        if isinstance(image, Path):
+            content = image.read_bytes()
+            filename = image.name
+        elif isinstance(image, bytes):
+            content = image
+            filename = "image"
+        else:
+            image.seek(0)
+            content = image.read()
+            filename = "image"
+        return {"image": (filename, content, "application/octet-stream")}
+
+    @staticmethod
+    def _result(response: httpx.Response, *, model: str, engine: str) -> AtrResult:
+        payload = response.json()
+        return AtrResult(
+            text=payload.get("text", ""),
+            confidence=float(payload.get("confidence", 0.0)),
+            model=payload.get("model", model),
+            engine=payload.get("engine", engine),
+            service_version=payload.get("version", "?"),
+        )

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -10,6 +10,9 @@ Env vars (set in .env.gpustack, git-ignored):
     EXTRACTION_MODEL     - model for person extraction (default qwen3-30b-a3b-instruct)
     ORCHESTRATOR_MODEL   - model for orchestration (default minimax-m2.7)
     QWEN3_VL_MODEL       - vision model for document OCR (default qwen3-vl-30b-a3b-instruct)
+    ATR_GATEWAY_URL      - serving-atr-inference base URL
+    ATR_API_KEY          - static X-API-Key credential (empty for local development)
+    ATR_HTTP_TIMEOUT     - gateway request timeout in seconds (default 300)
     OCR_ENGINE           - qwen3-vl | mistral (default qwen3-vl)
 """
 from __future__ import annotations
@@ -49,6 +52,12 @@ def _get(key: str, default=None):
 GPUSTACK_BASE_URL  = _get("GPUSTACK_BASE_URL",  "https://gpustack.unibe.ch/v1")
 GPUSTACK_API_KEY   = os.environ.get("GPUSTACK_API_KEY", "")
 GPUSTACK_TIMEOUT   = int(_get("GPUSTACK_TIMEOUT", "120"))
+
+# ATR gateway. The 300-second client budget matches the gateway engine budget;
+# shorter timeouts can misreport healthy cold-model or long-page requests.
+ATR_GATEWAY_URL = _get("ATR_GATEWAY_URL", "")
+ATR_API_KEY = _get("ATR_API_KEY", "")
+ATR_HTTP_TIMEOUT = float(_get("ATR_HTTP_TIMEOUT", "300"))
 
 # Model names - must match exactly how models are registered in GPUStack
 EXTRACTION_MODEL   = _get("EXTRACTION_MODEL",   "qwen3-30b-a3b-instruct")

--- a/tests/test_atr_client.py
+++ b/tests/test_atr_client.py
@@ -1,0 +1,100 @@
+"""Offline tests for the ATR gateway client."""
+
+import httpx
+import pytest
+from atr_client import AtrClient, AtrClientError
+
+
+def _client(handler, *, api_key="secret", timeout=300):
+    transport = httpx.MockTransport(handler)
+    http = httpx.Client(
+        base_url="https://atr.example",
+        headers={"X-API-Key": api_key},
+        timeout=timeout,
+        transport=transport,
+    )
+    return AtrClient(
+        "https://atr.example",
+        api_key=api_key,
+        timeout=timeout,
+        http_client=http,
+    )
+
+
+def test_health_and_models_contract_with_api_key():
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "ok"})
+        return httpx.Response(200, json={"models": [{"id": "kraken-a"}]})
+
+    client = _client(handler)
+    assert client.health_check() == {"status": "ok"}
+    assert client.list_models() == [{"id": "kraken-a"}]
+    assert [request.url.path for request in seen] == ["/health", "/models"]
+    assert all(request.headers["X-API-Key"] == "secret" for request in seen)
+
+
+def test_segment_posts_image_and_mode(tmp_path):
+    image_path = tmp_path / "page.png"
+    image_path.write_bytes(b"image")
+
+    def handler(request):
+        body = request.read()
+        assert request.url.path == "/segment"
+        assert b"page.png" in body
+        assert b"baseline" in body
+        return httpx.Response(200, json={"lines": [{"baseline": [[0, 0], [1, 1]]}]})
+
+    client = _client(handler)
+    result = client.segment(image_path, seg_mode="baseline")
+    assert len(result["lines"]) == 1
+
+
+def test_transcribe_uses_ocr_for_kraken_and_recognize_for_party():
+    paths = []
+
+    def handler(request):
+        paths.append(request.url.path)
+        return httpx.Response(
+            200,
+            json={
+                "text": "transcription",
+                "confidence": 0.9,
+                "model": "model-a",
+                "version": "1.2",
+            },
+        )
+
+    client = _client(handler)
+    kraken = client.transcribe(b"image", model="model-a", engine="kraken")
+    party = client.transcribe(b"image", model="model-b", engine="party")
+    assert paths == ["/ocr", "/recognize"]
+    assert kraken.text == "transcription"
+    assert kraken.confidence == 0.9
+    assert kraken.service_version == "1.2"
+    assert party.engine == "party"
+
+
+def test_transcribe_rejects_engine_not_supported_by_ocr():
+    client = _client(lambda _request: httpx.Response(200, json={}))
+    with pytest.raises(ValueError, match="kraken and trocr"):
+        client.transcribe(b"image", model="x", engine="unknown")
+
+
+def test_http_error_is_actionable():
+    client = _client(
+        lambda _request: httpx.Response(422, text="invalid multipart payload")
+    )
+    with pytest.raises(AtrClientError, match="422.*invalid multipart"):
+        client.segment(b"image")
+
+
+def test_default_timeout_matches_gateway_engine_budget(monkeypatch):
+    import atr_client
+
+    monkeypatch.setattr(atr_client, "ATR_HTTP_TIMEOUT", 300)
+    client = AtrClient("https://atr.example")
+    assert client.timeout == 300


### PR DESCRIPTION
Closes #71

## Summary
- add an ATR gateway client for `/health`, `/models`, `/segment`, `/recognize`, and `/ocr`
- add `ATR_GATEWAY_URL`, `ATR_API_KEY`, and a 300-second `ATR_HTTP_TIMEOUT`
- route party through `/recognize` and kraken/TrOCR through `/ocr`
- support paths, bytes, and in-memory image streams with actionable transport/HTTP errors
- document configuration and add `httpx` as a direct dependency

## Validation
- changed-file Ruff checks passed
- six mocked HTTP contract tests
- `python -m pytest tests/ -q` (120 passed)