### PR TITLE
Define tei production deployment contracts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ This directory contains active documentation. Stale/historical documents are in 
 | `LOCAL_LLM_ADAPTATION_PLAN.md` | GPUStack migration plan — Epic 1–8 roadmap, current as of 2026-07 |
 | `INTEGRATED_DATA_MODEL.md` | Data model for OUTREMER persons (HBLS + Wikidata + Königsfelden) |
 | `EPIC4_HBLS_MCP.md` | HBLS MCP server: deployment, API reference, Docker |
+| `adr/0001-tei-production-deployment.md` | **Proposed ADR** — tei.dh.unibe.ch production boundaries, capability policy, prerequisites |
+| `deployment/capabilities-v1.yaml` | Versioned machine-readable shared-capability and dependency inventory |
 | `AUTHORITY_REVIEW_WORKSHEET.md` | **Generated** — scholar worksheet for repairing (#98) and growing (#36) the authority adjudication gold. Regenerate with `python scripts/build_review_worksheet.py`; do not hand-edit |
 | `PROGRESS.md` | Project-wide progress tracker (root of repo) |
 

--- a/docs/adr/0001-tei-production-deployment.md
+++ b/docs/adr/0001-tei-production-deployment.md
@@ -1,0 +1,222 @@
+# ADR 0001: University production deployment and shared research capabilities
+
+- **Status:** Proposed — human approval required before infrastructure mutation
+- **Date:** 2026-08-11
+- **Decision owners:** Outremer maintainers and University of Bern DH infrastructure
+- **Tracking:** #110, Epic #116
+- **Machine-readable companion:** [`../deployment/capabilities-v1.yaml`](../deployment/capabilities-v1.yaml)
+
+## Context
+
+Outremer currently builds a static research interface and runs scheduled work in
+GitHub Actions. GitHub-hosted runners cannot reach University of Bern services;
+live model calls therefore fail or degrade to heuristic extraction. That is a
+useful offline test mode, but it is not an acceptable production publication
+path.
+
+The production system will run inside the university network on
+`tei.dh.unibe.ch`. It can reuse capabilities operated for
+[`thodel/agentic_historian`](https://github.com/thodel/agentic_historian):
+GPUStack inference and retrieval models, the ATR recognition gateway, MCP
+knowledge sources, QLever, Voyant, and selected tool contracts. Outremer's
+evidence-first records, prosopographic authority model, evaluation, and
+scholarly review semantics remain authoritative.
+
+This ADR defines boundaries and contracts. It does **not** authorize a bot to
+change DNS, nginx, systemd, firewall rules, credentials, or production data.
+
+## Decision
+
+### 1. Deployment shape
+
+Outremer will be a versioned application plus worker behind the existing nginx
+service. Its external base URL is configurable; the proposed value is
+`https://tei.dh.unibe.ch/outremer/`. The application must never assume ownership
+of `/` or use unqualified root-relative assets.
+
+Production inference and publication run inside the university network. GitHub
+Actions remains responsible for offline linting, unit/contract tests, fixture
+evaluation, and build artifacts. An approved inside-network runner or deployment
+agent performs live integration checks and release promotion (#112).
+
+Mutable research state is separated from immutable releases:
+
+- release: application, static assets, schemas, migrations, dependency lock;
+- state: evidence, review decisions, run state, provenance and audit events;
+- source: uploaded or mounted research material, governed independently;
+- cache: reproducible/disposable derived data;
+- secrets: host-managed credentials, never repository files or manifests.
+
+### 2. Integration rule: contracts, not repository internals
+
+Shared infrastructure is consumed through network contracts or a shared,
+version-pinned package. Outremer must not import `agentic_historian`'s Discord
+bot, repository-relative modules, or deployment state. Issue #90 decides the
+general sharing mechanism; this ADR constrains the result as follows:
+
+- network services (GPUStack, ATR, MCP, QLever, Voyant) use narrow adapters with
+  health/version discovery, timeouts, authentication and contract tests;
+- genuinely shared clients may use the package selected by #90/#87;
+- domain model conversion happens in Outremer anti-corruption adapters;
+- provider capability identifiers, not concrete model names or hosts, appear at
+  domain call sites;
+- resolved endpoint/service/model versions are recorded in run provenance.
+
+### 3. Required, optional and deferred capabilities
+
+The production profile has four classes, defined precisely in the companion
+manifest:
+
+- **Required:** application storage, GPUStack text inference, and provenance.
+  Failure blocks the affected run and publication.
+- **Conditionally required:** GPUStack vision and ATR are required when a source
+  needs recognition; MCP knowledge federation is required when federated linking
+  is selected. Failure blocks that stage rather than silently changing methods.
+- **Optional:** retrieval models, QLever and Voyant until their owning issue
+  promotes them. Their absence is visible and cannot erase or replace canonical
+  evidence.
+- **Deferred:** generic `agentic_historian` agent-tool orchestration. Reusable
+  source-description, entity, corpus-analysis and reporting tools require an
+  explicit Outremer adapter and scholarly-fit review in #113.
+
+### 4. Failure and fallback policy
+
+Production must fail visibly. In particular:
+
+- GPUStack text failure must not silently switch to heuristic extraction;
+- recognition failure must not turn an image-only source into empty text;
+- MCP/QLever unavailability must be distinguishable from a successful query
+  returning no candidates;
+- optional tools may degrade only to a declared state displayed in the UI,
+  structured logs and run provenance;
+- release promotion rejects outputs whose actual engine/capability profile does
+  not match the declared production profile;
+- every remote call has a bounded timeout and correlation/run identifier.
+
+Heuristic extraction remains available for offline development and explicitly
+labelled comparison runs. It is not publication-grade production inference.
+
+## Trust and network boundaries
+
+```mermaid
+flowchart LR
+    U[Scholar browser] -->|TLS| N[tei nginx /outremer/]
+    G[GitHub] -->|signed/pinned release artifact| D[Inside-network deployment agent]
+    N --> A[Outremer application]
+    A --> S[(Durable state and evidence)]
+    A --> W[Outremer worker]
+    W -->|OpenAI-compatible API| GPU[GPUStack]
+    W -->|X-API-Key| ATR[ATR gateway]
+    W -->|MCP contract| MCP[MCP knowledge federation]
+    W -->|SPARQL| QL[QLever]
+    W -->|corpus hand-off| V[Voyant]
+    D --> A
+
+    subgraph Public boundary
+      U
+      G
+    end
+    subgraph University network
+      N
+      D
+      A
+      W
+      S
+      GPU
+      ATR
+      MCP
+      QL
+      V
+    end
+```
+
+Only nginx is intended to receive browser traffic. Internal service exposure,
+ports and firewall allowlists are resolved by infrastructure owners during the
+approval checkpoint. The manifest therefore uses environment references and
+logical service names rather than inventing reachable public URLs.
+
+## Data classification
+
+- **Public:** released static site, approved evidence excerpts, published
+  authority data, aggregate evaluation and non-sensitive provenance.
+- **Internal:** service topology, model registry, operational metrics, detailed
+  dependency health and non-public research outputs.
+- **Restricted:** unpublished source material, reviewer/audit identities,
+  access-controlled corpora and raw application logs that may contain content.
+- **Secret:** API keys, service credentials, signing material, session secrets
+  and pseudonymisation salts.
+
+Adapters must declare the highest classification they send. Secrets are passed
+by host credential/environment mechanisms and must be redacted from health,
+logs, manifests, provenance and exported research packages.
+
+## Infrastructure prerequisites and owners
+
+Before #111–#115 change production infrastructure, a human owner must confirm:
+
+1. external URL path, DNS ownership and TLS termination;
+2. nginx routing and maximum upload/request duration;
+3. dedicated unprivileged application and deployment identities;
+4. firewall routes from worker to each approved internal service;
+5. service authentication and credential rotation ownership;
+6. durable state/source/cache paths, quotas and filesystem permissions;
+7. backup target, retention, encryption, restore owner and recovery objectives;
+8. logging/metrics destination, retention and restricted-data handling;
+9. inside-network runner/deployment mechanism and artifact verification;
+10. maintenance, incident escalation and rollback authority.
+
+Unknown values stay `TBD` in the manifest and are **blocking**, not invitations
+for bots to guess.
+
+## Dependency matrix
+
+| Capability or concern | Source/owner | Implementation | Validation |
+|---|---|---|---|
+| Deployment contracts and prerequisites | Outremer + DH infrastructure | #110 | Human ADR approval |
+| Runtime packaging, nginx/systemd, state layout | Outremer | #111, #86 | Staging install/rollback |
+| Inside-network release pipeline | DH infrastructure + Outremer | #112 | Live provenance gate |
+| GPUStack role routing | Shared infrastructure | #88, #113 | Offline contract + live fixture |
+| ATR recognition and engines | Shared infrastructure | #64, #87, #113 | #74, #77 and scanned fixture |
+| MCP federation/entity resolution | Shared infrastructure | #113 | At least one live source + empty/error distinction |
+| Offline authority/QLever | Shared infrastructure | #83, #113 | Snapshot/version provenance |
+| Voyant corpus hand-off | DH infrastructure | #113 | Staging corpus smoke test |
+| Shared-code ownership/versioning | Both repositories | #90 | Version pin + compatibility test |
+| Multi-user review and durable state | Outremer | #114 | Concurrency + restore test |
+| Health, telemetry and readiness | Outremer + DH infrastructure | #115 | Production rehearsal |
+
+## Consequences
+
+Positive consequences:
+
+- production artifacts are generated where the declared models and services are
+  actually reachable;
+- both research projects can share mature infrastructure without collapsing
+  their domain models or release cycles;
+- missing services and methodological degradation become auditable;
+- later bots have explicit contracts and ownership boundaries.
+
+Costs and trade-offs:
+
+- a university-network deployment path and operational ownership are required;
+- contract/version management adds work compared with direct imports;
+- some features remain unavailable until humans resolve infrastructure `TBD`s;
+- multi-user state, backup and observability turn the proof of concept into an
+  operated service rather than a static build.
+
+## Non-goals
+
+- replacing Outremer with the `agentic_historian` application or Discord bot;
+- copying every `agentic_historian` module irrespective of scholarly fit;
+- selecting exact production secrets, filesystem paths, ports or service
+  accounts in source control;
+- changing the Outremer evidence/authority model in this issue;
+- granting bots permission to modify production infrastructure.
+
+## Human approval checkpoint
+
+Change this ADR from **Proposed** to **Accepted** only after the maintainers and
+DH infrastructure owner approve the proposed URL, capability classifications,
+sharing boundary, data classifications, and all blocking prerequisites in
+`capabilities-v1.yaml`. Infrastructure issues may prepare templates beforehand,
+but must not apply host changes before that approval is recorded in the PR or
+issue.

--- a/docs/deployment/capabilities-v1.yaml
+++ b/docs/deployment/capabilities-v1.yaml
@@ -1,0 +1,276 @@
+schema_version: "1.0"
+profile: tei-production
+status: proposed
+last_updated: "2026-08-11"
+tracking:
+  epic: "https://github.com/thodel/outremer/issues/116"
+  issue: "https://github.com/thodel/outremer/issues/110"
+  adr: "docs/adr/0001-tei-production-deployment.md"
+
+deployment:
+  public_base_url:
+    proposed: "https://tei.dh.unibe.ch/outremer/"
+    configurable: true
+    environment: OUTREMER_PUBLIC_BASE_URL
+    owner: dh-infrastructure
+    approval: required
+  network_zone: university-internal
+  production_publication_policy:
+    reject_unexpected_fallback: true
+    reject_heuristic_extraction: true
+    require_release_manifest: true
+    require_capability_versions: true
+
+classifications:
+  public: Approved publication artifacts and non-sensitive provenance.
+  internal: Service topology, model inventory, operational metadata, non-public outputs.
+  restricted: Unpublished sources, reviewer identities, access-controlled corpora, content-bearing logs.
+  secret: Credentials, signing keys, session secrets, pseudonymisation salts.
+
+defaults:
+  owner: tbd
+  health_timeout_seconds: 10
+  retry_policy: bounded-exponential-backoff
+  secret_source: host-managed-environment-or-credential-store
+  observability:
+    correlation_id: required
+    redact_credentials: true
+    record_version: true
+    record_latency: true
+
+capabilities:
+  - id: outremer-state
+    class: required
+    provider: outremer
+    purpose: Durable evidence, review, provenance, audit, and run state.
+    contract: transactional-store-and-versioned-research-export
+    endpoint: null
+    endpoint_environment: OUTREMER_STATE_URL
+    owner: outremer-maintainers
+    authentication: least-privilege-service-identity
+    timeout_seconds: 30
+    data_classification: restricted
+    availability: required-for-application-readiness
+    fallback: none-fail-closed
+    provenance: schema-and-migration-version
+    implementation_issues: [111, 114]
+    validation_issue: 115
+
+  - id: gpustack-text
+    class: required
+    provider: agentic-historian-shared-infrastructure
+    purpose: Person extraction, metadata, entity and corpus text tasks.
+    contract: openai-compatible-v1-models-and-chat-completions
+    endpoint: null
+    endpoint_environment: GPUSTACK_BASE_URL
+    model_role: TEXT
+    model_environment: GPUSTACK_MODEL_TEXT
+    owner: dh-infrastructure
+    authentication: bearer-api-key
+    credential_environment: GPUSTACK_API_KEY
+    timeout_seconds_environment: GPUSTACK_TIMEOUT
+    timeout_seconds_default: 120
+    data_classification: restricted
+    availability: required-for-production-pipeline
+    fallback: block-run-and-publication
+    forbidden_production_fallbacks: [heuristic-extraction, third-party-llm]
+    provenance: endpoint-identity-service-version-resolved-model-parameters
+    implementation_issues: [88, 113]
+    validation_issue: 112
+
+  - id: gpustack-vision
+    class: conditionally-required
+    condition: Source requires page-level visual recognition or description.
+    provider: agentic-historian-shared-infrastructure
+    purpose: Page-level recognition and visual source analysis.
+    contract: openai-compatible-v1-models-and-chat-completions
+    endpoint: null
+    endpoint_environment: GPUSTACK_BASE_URL
+    model_role: VISION
+    model_environment: GPUSTACK_MODEL_VISION
+    owner: dh-infrastructure
+    authentication: bearer-api-key
+    credential_environment: GPUSTACK_API_KEY
+    timeout_seconds_environment: GPUSTACK_TIMEOUT
+    timeout_seconds_default: 120
+    data_classification: restricted
+    availability: required-for-visual-stage
+    fallback: block-visual-stage-no-empty-text
+    provenance: endpoint-identity-service-version-resolved-model-parameters
+    implementation_issues: [64, 88, 113]
+    validation_issue: 112
+
+  - id: gpustack-orchestrator
+    class: deferred
+    provider: agentic-historian-shared-infrastructure
+    purpose: Optional natural-language or Scholar-in-the-Loop planning.
+    contract: openai-compatible-v1-models-and-chat-completions
+    endpoint: null
+    endpoint_environment: GPUSTACK_BASE_URL
+    model_role: ORCHESTRATOR
+    model_environment: GPUSTACK_MODEL_ORCHESTRATOR
+    owner: dh-infrastructure
+    authentication: bearer-api-key
+    credential_environment: GPUSTACK_API_KEY
+    timeout_seconds_environment: GPUSTACK_TIMEOUT
+    timeout_seconds_default: 120
+    data_classification: restricted
+    availability: not-in-production-readiness-until-promoted
+    fallback: deterministic-explicit-workflow
+    provenance: endpoint-identity-service-version-resolved-model-parameters
+    implementation_issues: [88, 113]
+    validation_issue: 115
+
+  - id: gpustack-retrieval
+    class: optional
+    provider: agentic-historian-shared-infrastructure
+    purpose: Multilingual embeddings and reranking for candidate retrieval.
+    contract: openai-compatible-embedding-plus-provider-rerank-contract
+    endpoint: null
+    endpoint_environment: GPUSTACK_BASE_URL
+    model_environments: [GPUSTACK_MODEL_EMBEDDING, GPUSTACK_MODEL_RERANKER]
+    owner: dh-infrastructure
+    authentication: bearer-api-key
+    credential_environment: GPUSTACK_API_KEY
+    timeout_seconds_environment: GPUSTACK_TIMEOUT
+    timeout_seconds_default: 120
+    data_classification: restricted
+    availability: optional-until-evaluation-proves-and-promotes
+    fallback: existing-versioned-candidate-retrieval-with-degraded-state
+    provenance: endpoint-identity-model-version-and-retrieval-parameters
+    implementation_issues: [113]
+    validation_issue: 115
+
+  - id: atr-gateway
+    class: conditionally-required
+    condition: Source requires ATR recognition or ensemble recognition is enabled.
+    provider: serving-atr-inference
+    purpose: Model discovery, segmentation, Kraken/TrOCR/PARTY recognition, and OCR.
+    contract: "GET /health; GET /models; POST /segment; POST /recognize; POST /ocr"
+    endpoint: null
+    endpoint_environment: ATR_GATEWAY_URL
+    owner: dh-infrastructure
+    authentication: x-api-key
+    credential_environment: ATR_API_KEY
+    timeout_seconds_environment: ATR_HTTP_TIMEOUT
+    timeout_seconds_default: 300
+    data_classification: restricted
+    availability: required-for-selected-recognition-stage
+    fallback: block-recognition-no-empty-text
+    provenance: gateway-version-engine-model-segmentation-and-decoding-parameters
+    implementation_issues: [64, 87, 113]
+    validation_issue: 112
+
+  - id: mcp-knowledge-federation
+    class: conditionally-required
+    condition: A run selects federated knowledge linking.
+    provider: agentic-historian-knowledge-hub
+    purpose: Federated person/place authority search and entity resolution.
+    contract: mcp-versioned-person-result-contract
+    endpoint: null
+    endpoint_environment: MCP_BASE_URL
+    owner: dh-infrastructure-and-source-owners
+    authentication: tbd
+    credential_environment: MCP_API_KEY
+    timeout_seconds_environment: MCP_TIMEOUT
+    timeout_seconds_default: 30
+    data_classification: restricted
+    availability: required-for-federated-linking-stage
+    fallback: explicit-source-unavailable-not-empty-result
+    provenance: registry-version-source-versions-query-and-resolver-version
+    implementation_issues: [113]
+    validation_issue: 115
+
+  - id: qlever
+    class: optional
+    provider: agentic-historian-shared-infrastructure
+    purpose: Local SPARQL knowledge-graph query and reproducible authority snapshots.
+    contract: sparql-1.1-query
+    endpoint: null
+    endpoint_environment: QLEVER_ENDPOINT
+    owner: dh-infrastructure
+    authentication: tbd
+    credential_environment: QLEVER_API_KEY
+    timeout_seconds_environment: QLEVER_TIMEOUT
+    timeout_seconds_default: 60
+    data_classification: internal
+    availability: optional-until-promoted-by-authority-integration
+    fallback: pinned-versioned-local-snapshot-with-explicit-staleness
+    provenance: dataset-snapshot-index-and-service-version
+    implementation_issues: [83, 113]
+    validation_issue: 115
+
+  - id: voyant
+    class: optional
+    provider: dh-infrastructure
+    purpose: Scholar-initiated corpus exploration and analysis hand-off.
+    contract: voyant-corpus-upload-or-url-contract
+    endpoint: "https://tei.dh.unibe.ch/voyant/"
+    endpoint_environment: VOYANT_API_URL
+    owner: dh-infrastructure
+    authentication: tbd
+    timeout_seconds_environment: VOYANT_TIMEOUT
+    timeout_seconds_default: 120
+    data_classification: restricted
+    availability: optional-never-blocks-canonical-pipeline
+    fallback: export-versioned-plain-text-corpus-and-report-unavailable
+    provenance: corpus-id-service-version-input-artifact-digest
+    implementation_issues: [113]
+    validation_issue: 115
+
+  - id: agent-tool-registry
+    class: deferred
+    provider: agentic-historian
+    purpose: Discoverable source-description, entity, corpus-analysis, reporting, and orchestration tool contracts.
+    contract: provider-neutral-versioned-tool-descriptors
+    endpoint: null
+    endpoint_environment: OUTREMER_TOOL_PROVIDER_URL
+    owner: both-project-maintainers
+    authentication: tbd
+    timeout_seconds: 120
+    data_classification: restricted
+    availability: deferred-until-scholarly-fit-and-adapter-review
+    fallback: outremer-explicit-pipeline
+    excluded_components: [discord-bot, repository-relative-imports, deployment-state]
+    provenance: tool-id-contract-version-provider-version-input-output-artifact-digests
+    implementation_issues: [90, 113]
+    validation_issue: 115
+
+prerequisites:
+  blocking_human_approvals:
+    - id: url-dns-tls
+      owner: dh-infrastructure
+      value: TBD
+    - id: nginx-routing-and-limits
+      owner: dh-infrastructure
+      value: TBD
+    - id: application-and-deployment-service-identities
+      owner: dh-infrastructure
+      value: TBD
+    - id: firewall-service-allowlist
+      owner: dh-infrastructure
+      value: TBD
+    - id: credential-provisioning-and-rotation
+      owner: dh-infrastructure
+      value: TBD
+    - id: durable-source-state-cache-paths-and-quotas
+      owner: dh-infrastructure-and-outremer-maintainers
+      value: TBD
+    - id: backup-retention-encryption-rpo-rto-and-restore-owner
+      owner: dh-infrastructure-and-outremer-maintainers
+      value: TBD
+    - id: telemetry-destination-retention-and-access
+      owner: dh-infrastructure
+      value: TBD
+    - id: inside-network-runner-and-artifact-verification
+      owner: dh-infrastructure
+      value: TBD
+    - id: maintenance-incident-and-rollback-authority
+      owner: dh-infrastructure-and-outremer-maintainers
+      value: TBD
+
+non_goals:
+  - Replace Outremer with the agentic_historian application or Discord bot.
+  - Copy every agentic_historian module irrespective of scholarly fit.
+  - Store production secrets, concrete credentials, or restricted paths in this manifest.
+  - Authorize automated production infrastructure changes.


### PR DESCRIPTION
## What changed

- add proposed ADR 0001 for the `tei.dh.unibe.ch` production deployment
- define trust/network boundaries, state separation, data classification, failure semantics, and human-owned prerequisites
- add a versioned YAML inventory for ten shared capabilities spanning GPUStack, ATR, retrieval, MCP, QLever, Voyant, durable state, and the agent-tool seam
- map implementation and validation dependencies across Epics 13–20
- index both artifacts in the living documentation

## Key decision

Outremer consumes shared research infrastructure through versioned service or package contracts while retaining its own evidence, authority, evaluation, and review semantics. Production promotion fails on unexpected heuristic fallback. Unknown infrastructure details remain blocking `TBD` approvals instead of guessed configuration.

The ADR remains **Proposed**: merging the documentation does not authorize DNS, nginx, systemd, firewall, credential, or production-data changes. Acceptance requires the human checkpoint described in the ADR.

## Verification

- `git diff --check`
- parsed `docs/deployment/capabilities-v1.yaml` with `yaml.safe_load`
- asserted unique capability IDs, valid classifications, all required contract fields, and ten blocking approval entries
- secret/path scan found no committed credentials or host filesystem paths

Closes #110
