### PR TITLE
Package the tei production service

### DIFF
--- a/deploy/tei/README.md
+++ b/deploy/tei/README.md
@@ -1,0 +1,153 @@
+# Outremer deployment on `tei.dh.unibe.ch`
+
+This directory packages the current Outremer system as two separate concerns:
+
+- `outremer-web.service` serves the generated static research interface on a
+  loopback port; nginx publishes it below a configurable URL prefix.
+- `outremer-worker.service` is a bounded, one-shot pipeline job. Its timer is
+  optional; manual and deployment-runner invocation use the same unit.
+
+Server-side multi-user review/API state is intentionally not invented here; it
+belongs to #114. The nginx template reserves `<base>/api/` for that service.
+
+All commands below are an operator runbook, not an automated authorization to
+change production. Replace example version `v0.1.0` and paths only after the
+deployment ADR (#110) and infrastructure prerequisites are approved.
+
+## Filesystem contract
+
+```text
+/opt/outremer/
+  releases/<version>/       immutable checkout + .venv
+  current -> releases/...   atomic release pointer
+/var/lib/outremer/
+  source/                   governed source inputs
+  state/                    evidence, decisions, run state, generated site
+  cache/                    disposable/rebuildable cache (or /var/cache)
+/var/backups/outremer/      encrypted/versioned backup target (operator-selected)
+/etc/outremer/
+  outremer.env              host-managed secrets and topology, mode 0640
+```
+
+Never store mutable state or credentials under a release directory. The static
+site in `site/` is a release/export seed; production pipeline output is directed
+to `OUTREMER_SITE_DIR`. Until #114 moves reviews server-side, browser-local
+review data must still be exported before browser storage is cleared.
+
+## Render and inspect configuration
+
+Rendering accepts topology only and refuses unsafe root paths, traversal, unsafe
+account names, and non-loopback upstreams:
+
+```bash
+python3 deploy/tei/render_config.py \
+  --public-base-path /outremer/ \
+  --release-root /opt/outremer \
+  --state-root /var/lib/outremer \
+  --runtime-user outremer \
+  --output-dir build/tei
+```
+
+Inspect the output before installing it. In particular confirm the URL prefix,
+ports, runtime identity, filesystem paths, and nginx server-block context.
+
+## Clean staging installation
+
+1. Create the dedicated system account and approved directories. Grant the
+   account read access to `/opt/outremer` and only the required write access to
+   `/var/lib/outremer`; do not grant a login shell or sudo.
+2. Fetch a signed tag/commit or immutable release artifact into
+   `/opt/outremer/releases/v0.1.0`. Record its commit and artifact digest.
+3. Create a Python 3.12 virtual environment inside that release and install from
+   `requirements.lock.txt`, then install the local project without resolving new
+   dependencies:
+
+   ```bash
+   python3.12 -m venv /opt/outremer/releases/v0.1.0/.venv
+   /opt/outremer/releases/v0.1.0/.venv/bin/pip install -r requirements.lock.txt
+   /opt/outremer/releases/v0.1.0/.venv/bin/pip install -e . --no-deps
+   ```
+
+4. Seed `/var/lib/outremer/state/site` from the release's `site/` directory on
+   the first installation. On upgrades, sync application assets without deleting
+   generated `data/`, `evidence/`, review exports, or other mutable artifacts.
+5. Copy `outremer.env.example` to `/etc/outremer/outremer.env`, replace every
+   `TBD` through the approved secret/topology process, set ownership
+   `root:outremer`, and mode `0640`.
+6. Render templates. Install the systemd units in `/etc/systemd/system/` and the
+   nginx fragment in the approved `tei.dh.unibe.ch` TLS server block.
+7. Point `current` at the release with an atomic symlink replacement, reload
+   systemd, run `nginx -t`, then reload nginx.
+8. Start `outremer-web.service`. Run the worker manually only after backend
+   preflight; #112 will automate the live provenance gate.
+9. Smoke-test `<base>/`, representative HTML/JS/CSS/data paths, the redirect from
+   the missing trailing slash, and a deliberate `/api/` request. An unavailable
+   future API must fail as an API request, never return the site index.
+
+## Upgrade
+
+1. Back up and integrity-check mutable state before migration.
+2. Install the new pinned release beside the old one; never modify `current`.
+3. Build its virtual environment from the lock file and run offline tests.
+4. Stop the timer and wait for any active worker to finish. Do not kill an
+   inference job midway unless the incident runbook requires it.
+5. Apply documented, forward-compatible state migrations and record their
+   version. #114 owns transactional database migrations when introduced.
+6. Atomically repoint `current`, restart the web unit, run the smoke test, then
+   re-enable the timer. #112 adds staging-to-production promotion and manifests.
+
+## Rollback
+
+Application rollback is an atomic `current` symlink switch to the immediately
+previous pinned release followed by a web restart. Before switching:
+
+- stop the timer and ensure the worker is inactive;
+- check whether the release changed mutable-state schemas;
+- restore the pre-upgrade snapshot if the older release cannot read the migrated
+  schema; never run an old binary against incompatible newer state;
+- run the same URL-prefix and representative-artifact smoke tests;
+- record release digests, state snapshot, reason, operator, and timestamps.
+
+Rehearse this procedure on staging before production promotion. Keep at least the
+current and previous verified release until the backup retention policy says
+otherwise.
+
+## Backup and restore
+
+Back up mutable state, governed source inputs where permitted, review exports,
+audit/provenance records, and the release manifest. Do not back up rebuildable
+caches unless recovery time requires it. Secrets use the university credential
+backup process and must not be copied into research-data archives.
+
+A backup is successful only after an automated integrity check and a periodic
+staging restore. Restore into empty state paths, verify ownership/modes, validate
+schemas and artifact digests, start the web service, then run an offline fixture
+before permitting a live pipeline job.
+
+RPO, RTO, retention, encryption, backup destination and restore ownership remain
+blocking infrastructure decisions in #110; bots must not invent them.
+
+## Disaster recovery
+
+For loss of the host, rebuild a clean host from a pinned release, render reviewed
+configuration, restore the latest verified mutable-state snapshot, restore
+credentials through the approved channel, validate dependency routes, and run
+the readiness suite from #115. DNS or proxy cutover occurs only after evidence,
+decisions, provenance, and run-state integrity checks pass.
+
+For compromise, isolate the host first, preserve logs according to policy,
+rotate all service/session credentials, rebuild rather than trusting the old
+runtime, and review published artifacts produced during the affected interval.
+
+## Operator checks
+
+```bash
+systemctl status outremer-web.service
+systemctl status outremer-worker.service
+systemctl list-timers outremer-worker.timer
+journalctl -u outremer-web.service -u outremer-worker.service
+nginx -t
+```
+
+Monitoring, readiness, alert thresholds and production rehearsal are completed
+by #115.

--- a/deploy/tei/outremer.env.example
+++ b/deploy/tei/outremer.env.example
@@ -1,0 +1,28 @@
+# Install as /etc/outremer/outremer.env, mode 0640, readable only by root and
+# the Outremer service group. Values here are placeholders; never commit secrets.
+
+# Mutable paths live outside the immutable release directory.
+OUTREMER_SOURCE_DIR=/var/lib/outremer/source
+OUTREMER_SITE_DIR=/var/lib/outremer/state/site
+OUTREMER_STATE_DIR=/var/lib/outremer/state
+OUTREMER_BIB_DIR=/var/lib/outremer/state/bib
+OUTREMER_EVIDENCE_DIR=/var/lib/outremer/state/evidence
+OUTREMER_ENTITY_FEEDBACK_PATH=/var/lib/outremer/state/entity_feedback.json
+OUTREMER_REVIEW_DECISIONS_PATH=/var/lib/outremer/state/decisions.json
+OUTREMER_CACHE_DIR=/var/cache/outremer
+OUTREMER_WEB_PORT=8088
+
+# University-hosted capabilities. Infrastructure owners provide resolved values.
+GPUSTACK_BASE_URL=TBD
+GPUSTACK_API_KEY=TBD
+ATR_GATEWAY_URL=TBD
+ATR_API_KEY=TBD
+
+# Preserve current names until #88 lands role-based aliases on main.
+EXTRACTION_MODEL=TBD
+ORCHESTRATOR_MODEL=TBD
+QWEN3_VL_MODEL=TBD
+
+# Production must not publish heuristic fallback output. The provenance gate in
+# #112 enforces this; this marker allows operators to distinguish the profile.
+OUTREMER_DEPLOYMENT_PROFILE=tei-production

--- a/deploy/tei/render_config.py
+++ b/deploy/tei/render_config.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Render validated tei.dh.unibe.ch deployment templates.
+
+The renderer deliberately accepts only non-secret topology values. Credentials
+belong in the host-managed environment file referenced by the systemd units.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+TOKENS = {
+    "PUBLIC_BASE_PATH",
+    "PUBLIC_BASE_PATH_NO_SLASH",
+    "RELEASE_ROOT",
+    "STATE_ROOT",
+    "RUNTIME_USER",
+    "WEB_UPSTREAM",
+    "API_UPSTREAM",
+}
+TOKEN_RE = re.compile(r"@([A-Z_]+)@")
+SAFE_USER_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+
+
+def public_base_path(value: str) -> str:
+    """Return a canonical single-segment URL prefix with leading/trailing `/`."""
+    if not value.startswith("/") or not value.endswith("/"):
+        raise argparse.ArgumentTypeError("base path must start and end with '/'")
+    if value == "/" or "//" in value or value.count("/") != 2:
+        raise argparse.ArgumentTypeError("base path must be one non-root URL segment")
+    segment = value.strip("/")
+    if segment in {".", ".."}:
+        raise argparse.ArgumentTypeError("base path cannot be a traversal segment")
+    if not re.fullmatch(r"[A-Za-z0-9._~-]+", segment):
+        raise argparse.ArgumentTypeError("base path contains unsafe characters")
+    return value
+
+
+def absolute_path(value: str) -> str:
+    path = Path(value)
+    if not path.is_absolute() or ".." in path.parts or value == "/":
+        raise argparse.ArgumentTypeError("path must be absolute, non-root, and contain no '..'")
+    return str(path)
+
+
+def runtime_user(value: str) -> str:
+    if not SAFE_USER_RE.fullmatch(value):
+        raise argparse.ArgumentTypeError("runtime user is not a safe system account name")
+    return value
+
+
+def upstream(value: str) -> str:
+    if not re.fullmatch(r"http://127\.0\.0\.1:[1-9][0-9]{0,4}", value):
+        raise argparse.ArgumentTypeError("upstream must be an IPv4 loopback HTTP URL with port")
+    if int(value.rsplit(":", 1)[1]) > 65535:
+        raise argparse.ArgumentTypeError("upstream port must be <= 65535")
+    return value
+
+
+def render_text(template: str, values: dict[str, str]) -> str:
+    present = set(TOKEN_RE.findall(template))
+    unknown = present - TOKENS
+    missing = present - values.keys()
+    if unknown or missing:
+        raise ValueError(f"invalid template tokens: unknown={sorted(unknown)}, missing={sorted(missing)}")
+    rendered = TOKEN_RE.sub(lambda match: values[match.group(1)], template)
+    leftovers = TOKEN_RE.findall(rendered)
+    if leftovers:
+        raise ValueError(f"unresolved template tokens: {sorted(set(leftovers))}")
+    return rendered
+
+
+def render_directory(template_dir: Path, output_dir: Path, values: dict[str, str]) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rendered: list[Path] = []
+    for source in sorted(template_dir.glob("*.template")):
+        target = output_dir / source.name.removesuffix(".template")
+        target.write_text(render_text(source.read_text(), values))
+        rendered.append(target)
+    if not rendered:
+        raise ValueError(f"no templates found in {template_dir}")
+    return rendered
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--public-base-path", type=public_base_path, default="/outremer/")
+    result.add_argument("--release-root", type=absolute_path, default="/opt/outremer")
+    result.add_argument("--state-root", type=absolute_path, default="/var/lib/outremer")
+    result.add_argument("--runtime-user", type=runtime_user, default="outremer")
+    result.add_argument("--web-upstream", type=upstream, default="http://127.0.0.1:8088")
+    result.add_argument("--api-upstream", type=upstream, default="http://127.0.0.1:8089")
+    result.add_argument("--output-dir", type=Path, required=True)
+    result.add_argument(
+        "--template-dir",
+        type=Path,
+        default=Path(__file__).with_name("templates"),
+    )
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    values = {
+        "PUBLIC_BASE_PATH": args.public_base_path,
+        "PUBLIC_BASE_PATH_NO_SLASH": args.public_base_path.rstrip("/"),
+        "RELEASE_ROOT": args.release_root,
+        "STATE_ROOT": args.state_root,
+        "RUNTIME_USER": args.runtime_user,
+        "WEB_UPSTREAM": args.web_upstream,
+        "API_UPSTREAM": args.api_upstream,
+    }
+    for path in render_directory(args.template_dir, args.output_dir, values):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/tei/templates/outremer-web.service.template
+++ b/deploy/tei/templates/outremer-web.service.template
@@ -1,0 +1,37 @@
+[Unit]
+Description=Outremer static research interface
+After=network.target
+ConditionPathIsDirectory=@STATE_ROOT@/state/site
+
+[Service]
+Type=simple
+User=@RUNTIME_USER@
+Group=@RUNTIME_USER@
+WorkingDirectory=@RELEASE_ROOT@/current
+EnvironmentFile=/etc/outremer/outremer.env
+ExecStart=@RELEASE_ROOT@/current/.venv/bin/python -m http.server ${OUTREMER_WEB_PORT} --bind 127.0.0.1 --directory @STATE_ROOT@/state/site
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=30s
+TasksMax=128
+MemoryMax=512M
+CPUQuota=200%
+
+# The web process needs no mutable filesystem access.
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SystemCallArchitectures=native
+ReadOnlyPaths=@RELEASE_ROOT@
+ReadOnlyPaths=@STATE_ROOT@
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/tei/templates/outremer-worker.service.template
+++ b/deploy/tei/templates/outremer-worker.service.template
@@ -1,0 +1,37 @@
+[Unit]
+Description=Outremer production pipeline worker
+After=network-online.target
+Wants=network-online.target
+ConditionPathIsDirectory=@RELEASE_ROOT@/current
+
+[Service]
+Type=oneshot
+User=@RUNTIME_USER@
+Group=@RUNTIME_USER@
+WorkingDirectory=@RELEASE_ROOT@/current
+EnvironmentFile=/etc/outremer/outremer.env
+ExecStart=@RELEASE_ROOT@/current/.venv/bin/python scripts/run_pipeline.py --input-dir ${OUTREMER_SOURCE_DIR} --site-dir ${OUTREMER_SITE_DIR} --bib-dir ${OUTREMER_BIB_DIR} --evidence-dir ${OUTREMER_EVIDENCE_DIR} --entity-feedback-path ${OUTREMER_ENTITY_FEEDBACK_PATH} --review-decisions-path ${OUTREMER_REVIEW_DECISIONS_PATH}
+TimeoutStartSec=6h
+UMask=0027
+TasksMax=512
+MemoryMax=8G
+CPUQuota=400%
+
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SystemCallArchitectures=native
+ReadOnlyPaths=@RELEASE_ROOT@
+ReadWritePaths=@STATE_ROOT@
+
+# Failure is visible to systemd and monitoring; no Restart loop for expensive jobs.
+StandardOutput=journal
+StandardError=journal

--- a/deploy/tei/templates/outremer-worker.timer.template
+++ b/deploy/tei/templates/outremer-worker.timer.template
@@ -1,0 +1,11 @@
+[Unit]
+Description=Schedule the Outremer production pipeline
+
+[Timer]
+OnCalendar=*-*-* 03:00:00 Europe/Zurich
+Persistent=true
+RandomizedDelaySec=10m
+Unit=outremer-worker.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/tei/templates/outremer.nginx.conf.template
+++ b/deploy/tei/templates/outremer.nginx.conf.template
@@ -1,0 +1,37 @@
+# Include inside the TLS server block for tei.dh.unibe.ch.
+# nginx terminates TLS; both upstreams listen on loopback only.
+
+location = @PUBLIC_BASE_PATH_NO_SLASH@ {
+    return 308 @PUBLIC_BASE_PATH@;
+}
+
+# Reserve the server-side review/API boundary introduced by #114. Keeping it
+# more specific than the site route prevents an API failure from falling through
+# to static HTML.
+location ^~ @PUBLIC_BASE_PATH@api/ {
+    proxy_pass @API_UPSTREAM@/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Prefix @PUBLIC_BASE_PATH@;
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+    client_max_body_size 100m;
+    proxy_buffering off;
+}
+
+location ^~ @PUBLIC_BASE_PATH@ {
+    proxy_pass @WEB_UPSTREAM@/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Prefix @PUBLIC_BASE_PATH@;
+    proxy_read_timeout 60s;
+    proxy_redirect off;
+}

--- a/tests/test_deployment_templates.py
+++ b/tests/test_deployment_templates.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+RENDERER_PATH = ROOT / "deploy" / "tei" / "render_config.py"
+SPEC = importlib.util.spec_from_file_location("tei_render_config", RENDERER_PATH)
+assert SPEC and SPEC.loader
+renderer = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(renderer)
+
+
+def values(**overrides: str) -> dict[str, str]:
+    result = {
+        "PUBLIC_BASE_PATH": "/outremer/",
+        "PUBLIC_BASE_PATH_NO_SLASH": "/outremer",
+        "RELEASE_ROOT": "/opt/outremer",
+        "STATE_ROOT": "/var/lib/outremer",
+        "RUNTIME_USER": "outremer",
+        "WEB_UPSTREAM": "http://127.0.0.1:8088",
+        "API_UPSTREAM": "http://127.0.0.1:8089",
+    }
+    result.update(overrides)
+    return result
+
+
+def test_render_all_templates_without_unresolved_tokens(tmp_path: Path) -> None:
+    rendered = renderer.render_directory(
+        ROOT / "deploy" / "tei" / "templates", tmp_path, values()
+    )
+
+    assert {path.name for path in rendered} == {
+        "outremer-web.service",
+        "outremer-worker.service",
+        "outremer-worker.timer",
+        "outremer.nginx.conf",
+    }
+    combined = "\n".join(path.read_text() for path in rendered)
+    assert not renderer.TOKEN_RE.search(combined)
+    assert "/outremer/" in combined
+    assert "/opt/outremer/current" in combined
+    assert "/var/lib/outremer" in combined
+    assert "--evidence-dir ${OUTREMER_EVIDENCE_DIR}" in combined
+    assert "--review-decisions-path ${OUTREMER_REVIEW_DECISIONS_PATH}" in combined
+    assert "ProtectSystem=strict" in combined
+    assert "NoNewPrivileges=true" in combined
+    assert "MemoryMax=" in combined
+
+
+def test_nginx_orders_api_before_static_and_forwards_prefix(tmp_path: Path) -> None:
+    renderer.render_directory(ROOT / "deploy" / "tei" / "templates", tmp_path, values())
+    nginx = (tmp_path / "outremer.nginx.conf").read_text()
+
+    assert nginx.index("location ^~ /outremer/api/") < nginx.index(
+        "location ^~ /outremer/ {"
+    )
+    assert "proxy_set_header X-Forwarded-Prefix /outremer/;" in nginx
+    assert "proxy_pass http://127.0.0.1:8088/;" in nginx
+    assert "proxy_pass http://127.0.0.1:8089/;" in nginx
+    assert "location = /outremer {" in nginx
+    assert "return 308 /outremer/;" in nginx
+
+
+@pytest.mark.parametrize("bad", ["/", "outremer/", "/outremer", "/a/b/", "/../"])
+def test_public_base_path_rejects_unsafe_values(bad: str) -> None:
+    with pytest.raises(Exception):
+        renderer.public_base_path(bad)
+
+
+@pytest.mark.parametrize("bad", ["/", "relative", "/opt/../root"])
+def test_absolute_path_rejects_broad_or_unsafe_values(bad: str) -> None:
+    with pytest.raises(Exception):
+        renderer.absolute_path(bad)
+
+
+def test_upstream_must_be_loopback() -> None:
+    with pytest.raises(Exception):
+        renderer.upstream("https://example.org:8088")
+    with pytest.raises(Exception):
+        renderer.upstream("http://0.0.0.0:8088")
+    assert renderer.upstream("http://127.0.0.1:8088") == "http://127.0.0.1:8088"
+
+
+def test_unknown_template_token_fails() -> None:
+    with pytest.raises(ValueError, match="unknown"):
+        renderer.render_text("@NOT_ALLOWED@", values())


### PR DESCRIPTION
## What changed

- add a reproducible `tei.dh.unibe.ch` deployment layout with immutable releases and external mutable state
- add hardened systemd templates for the static web process and one-shot pipeline worker, plus an optional timer
- add a configurable nginx subpath template with a distinct reserved API boundary, forwarded headers, upload/time limits, and loopback-only upstreams
- add a validated renderer that rejects root/traversal paths, unsafe account names, unqualified prefixes, unknown tokens, and non-loopback upstreams
- add a placeholder-only host environment template
- add install, upgrade, rollback, backup/restore, disaster-recovery, and operator runbooks
- add 12 offline tests covering rendering, prefix routing, hardening, path validation, and unresolved tokens

## Deployment model

The current system is packaged honestly as a generated static research interface plus a separate pipeline worker. The worker writes evidence, decisions, bibliography, and generated site data outside the immutable release tree. The `/api/` boundary is reserved for #114 rather than inventing a server-side review backend in this issue.

This PR prepares and tests templates only. It does not change DNS, nginx, systemd, firewall rules, credentials, or production data. It is branched directly from `origin/main`, not stacked on unmerged #117.

## Verification

- `pytest -q tests/test_deployment_templates.py` — 12 passed
- `ruff check tests/test_deployment_templates.py deploy/tei/render_config.py`
- rendered both default `/outremer/` and custom `/research/` configurations with no unresolved tokens
- `git diff --check`
- canonical full suite locally: 194 passed, 1 skipped, 1 pre-existing exact-float comparison failure under host Python 3.10; GitHub CI runs the supported Python 3.12 matrix

Closes #111
