### PR TITLE
Gate inside-network releases by live provenance

### DIFF
--- a/.github/workflows/tei-live-release.yml
+++ b/.github/workflows/tei-live-release.yml
@@ -1,0 +1,182 @@
+name: TEI live validation and release
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Validate staging, promote the validated release, or roll back production
+        type: choice
+        options: [validate, promote, rollback]
+        default: validate
+        required: true
+      ref:
+        description: Git ref to validate/promote (ignored for rollback)
+        type: string
+        default: main
+        required: true
+      rollback_commit:
+        description: Previously verified commit directory to restore
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+# Never cancel an inference or promotion midway. The host-side flock also covers
+# manual and scheduled jobs outside GitHub Actions.
+concurrency:
+  group: tei-production-release
+  cancel-in-progress: false
+
+jobs:
+  staging:
+    if: inputs.action != 'rollback'
+    runs-on: [self-hosted, linux, outremer-tei]
+    environment: tei-staging
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
+      release_dir: ${{ steps.release.outputs.release_dir }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Validate, exercise live backends, and stage immutable release
+        id: release
+        env:
+          OUTREMER_ENV_FILE: ${{ vars.OUTREMER_ENV_FILE }}
+          OUTREMER_LIVE_CONFIG: ${{ vars.OUTREMER_LIVE_CONFIG }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${OUTREMER_ENV_FILE}" && test -r "${OUTREMER_ENV_FILE}"
+          test -n "${OUTREMER_LIVE_CONFIG}" && test -r "${OUTREMER_LIVE_CONFIG}"
+          set -a
+          source "${OUTREMER_ENV_FILE}"
+          set +a
+
+          exec 9>/var/lock/outremer-release.lock
+          flock -n 9 || { echo 'another Outremer release/pipeline job is active'; exit 1; }
+
+          commit="$(git rev-parse HEAD)"
+          work="${OUTREMER_STAGING_DIR}/runs/${GITHUB_RUN_ID}"
+          staging_release_root="${work}/release-root"
+          release_dir="${staging_release_root}/releases/${commit}"
+          mkdir -p "${work}/text/site" "${work}/scan/site" "${release_dir}"
+          cp -a site/. "${work}/text/site/"
+          cp -a site/. "${work}/scan/site/"
+
+          python3.12 -m venv .release-venv
+          .release-venv/bin/pip install -r requirements.lock.txt
+          .release-venv/bin/pip install -e . --no-deps
+
+          .release-venv/bin/python scripts/release_control.py preflight \
+            --config "${OUTREMER_LIVE_CONFIG}" --output "${work}/preflight.json"
+
+          .release-venv/bin/python scripts/run_pipeline.py \
+            --file data/raw/RileySmith-MotivesEarliestCrusaders-1983.pdf \
+            --site-dir "${work}/text/site" --bib-dir "${work}/text/bib" \
+            --evidence-dir "${work}/text/evidence" \
+            --entity-feedback-path "${work}/text/entity-feedback.json" --llm-metadata
+          cp data/staging/run_report.json "${work}/text-run-report.json"
+          .release-venv/bin/python scripts/release_control.py gate \
+            --report "${work}/text-run-report.json" --output "${work}/text-gate.json" \
+            --expected-model "${EXTRACTION_MODEL}"
+
+          .release-venv/bin/python scripts/run_pipeline.py \
+            --file tests/fixtures/scans/magna-carta-1215-image-only.pdf \
+            --site-dir "${work}/scan/site" --bib-dir "${work}/scan/bib" \
+            --evidence-dir "${work}/scan/evidence" \
+            --entity-feedback-path "${work}/scan/entity-feedback.json"
+          cp data/staging/run_report.json "${work}/scan-run-report.json"
+          .release-venv/bin/python scripts/release_control.py gate \
+            --report "${work}/scan-run-report.json" --output "${work}/scan-gate.json" \
+            --expected-model "${EXTRACTION_MODEL}" --require-recognition
+
+          .release-venv/bin/python scripts/release_control.py manifest \
+            --preflight "${work}/preflight.json" \
+            --report "${work}/text-run-report.json" \
+            --report "${work}/scan-run-report.json" \
+            --output "${work}/release-manifest.json"
+
+          # run_pipeline has a fixed local report path. The verified copies live
+          # in university staging; never let this transient file enter a release.
+          rm -f data/staging/run_report.json
+
+          rsync -a --delete --exclude .git --exclude .release-venv ./ "${release_dir}/"
+          mv .release-venv "${release_dir}/.venv"
+          cp "${work}/release-manifest.json" "${release_dir}/release-manifest.json"
+          chmod -R a-w "${release_dir}"
+
+          python3 scripts/promote_release.py promote \
+            --release-root "${staging_release_root}" --release "${release_dir}" \
+            --history "${work}/staging-history.jsonl"
+          sudo systemctl restart outremer-staging-web.service
+          curl --fail --silent --show-error "${OUTREMER_STAGING_SMOKE_URL}index.html" >/dev/null
+          curl --fail --silent --show-error "${OUTREMER_STAGING_SMOKE_URL}app.js" >/dev/null
+
+          echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
+          echo "release_dir=${release_dir}" >> "${GITHUB_OUTPUT}"
+
+  production:
+    if: inputs.action == 'promote' && needs.staging.result == 'success'
+    needs: staging
+    runs-on: [self-hosted, linux, outremer-tei]
+    environment: tei-production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.staging.outputs.commit }}
+          fetch-depth: 1
+      - name: Promote exact staging release
+        env:
+          OUTREMER_RELEASE_ROOT: ${{ vars.OUTREMER_RELEASE_ROOT }}
+          OUTREMER_PRODUCTION_SMOKE_URL: ${{ vars.OUTREMER_PRODUCTION_SMOKE_URL }}
+          STAGING_RELEASE_DIR: ${{ needs.staging.outputs.release_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${OUTREMER_RELEASE_ROOT}"
+          test -n "${OUTREMER_PRODUCTION_SMOKE_URL}"
+          exec 9>/var/lock/outremer-release.lock
+          flock -n 9 || { echo 'another Outremer release/pipeline job is active'; exit 1; }
+          commit="$(git rev-parse HEAD)"
+          test "${commit}" = "$(basename "${STAGING_RELEASE_DIR}")"
+          production_release="${OUTREMER_RELEASE_ROOT}/releases/${commit}"
+          if test ! -e "${production_release}"; then
+            cp -a "${STAGING_RELEASE_DIR}" "${production_release}"
+          fi
+          python3 scripts/promote_release.py promote \
+            --release-root "${OUTREMER_RELEASE_ROOT}" --release "${production_release}" \
+            --history "${OUTREMER_RELEASE_ROOT}/production-history.jsonl"
+          sudo systemctl restart outremer-web.service
+          curl --fail --silent --show-error "${OUTREMER_PRODUCTION_SMOKE_URL}index.html" >/dev/null
+          curl --fail --silent --show-error "${OUTREMER_PRODUCTION_SMOKE_URL}app.js" >/dev/null
+
+  rollback:
+    if: inputs.action == 'rollback'
+    runs-on: [self-hosted, linux, outremer-tei]
+    environment: tei-production
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore a previously verified immutable release
+        env:
+          OUTREMER_RELEASE_ROOT: ${{ vars.OUTREMER_RELEASE_ROOT }}
+          OUTREMER_PRODUCTION_SMOKE_URL: ${{ vars.OUTREMER_PRODUCTION_SMOKE_URL }}
+          ROLLBACK_COMMIT: ${{ inputs.rollback_commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${OUTREMER_RELEASE_ROOT}"
+          test -n "${OUTREMER_PRODUCTION_SMOKE_URL}"
+          test "${ROLLBACK_COMMIT}" = "$(printf '%s' "${ROLLBACK_COMMIT}" | tr -cd '0-9a-f')"
+          test "${#ROLLBACK_COMMIT}" -eq 40
+          exec 9>/var/lock/outremer-release.lock
+          flock -n 9 || { echo 'another Outremer release/pipeline job is active'; exit 1; }
+          python3 scripts/promote_release.py rollback \
+            --release-root "${OUTREMER_RELEASE_ROOT}" \
+            --release "${OUTREMER_RELEASE_ROOT}/releases/${ROLLBACK_COMMIT}" \
+            --history "${OUTREMER_RELEASE_ROOT}/production-history.jsonl"
+          sudo systemctl restart outremer-web.service
+          curl --fail --silent --show-error "${OUTREMER_PRODUCTION_SMOKE_URL}index.html" >/dev/null

--- a/deploy/tei/live-capabilities.example.json
+++ b/deploy/tei/live-capabilities.example.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "profile": "tei-production",
+  "capabilities": [
+    {
+      "id": "gpustack",
+      "required": true,
+      "kind": "openai_models",
+      "url_env": "GPUSTACK_BASE_URL",
+      "health_path": "/models",
+      "auth": "bearer",
+      "credential_env": "GPUSTACK_API_KEY",
+      "required_model_envs": [
+        "EXTRACTION_MODEL",
+        "QWEN3_VL_MODEL",
+        "ORCHESTRATOR_MODEL"
+      ],
+      "timeout_seconds": 15
+    },
+    {
+      "id": "atr",
+      "required": true,
+      "kind": "atr",
+      "url_env": "ATR_GATEWAY_URL",
+      "health_path": "/health",
+      "models_path": "/models",
+      "auth": "x-api-key",
+      "credential_env": "ATR_API_KEY",
+      "timeout_seconds": 15
+    },
+    {
+      "id": "mcp",
+      "required": false,
+      "kind": "http_json",
+      "url_env": "MCP_BASE_URL",
+      "health_path": "/health",
+      "auth": "bearer-optional",
+      "credential_env": "MCP_API_KEY",
+      "timeout_seconds": 10
+    },
+    {
+      "id": "qlever",
+      "required": false,
+      "kind": "http",
+      "url_env": "QLEVER_ENDPOINT",
+      "health_path": "/",
+      "auth": "none",
+      "timeout_seconds": 10
+    },
+    {
+      "id": "voyant",
+      "required": false,
+      "kind": "http",
+      "url_env": "VOYANT_API_URL",
+      "health_path": "/",
+      "auth": "none",
+      "timeout_seconds": 10
+    }
+  ],
+  "storage": [
+    {"id": "source", "path_env": "OUTREMER_SOURCE_DIR", "writable": false},
+    {"id": "state", "path_env": "OUTREMER_STATE_DIR", "writable": true},
+    {"id": "staging", "path_env": "OUTREMER_STAGING_DIR", "writable": true}
+  ],
+  "schema": {"evidence": "1.0.0"}
+}

--- a/docs/TEI_RELEASE_CONTROL.md
+++ b/docs/TEI_RELEASE_CONTROL.md
@@ -1,0 +1,115 @@
+# TEI inside-network validation and release control
+
+Issue #112 separates two fundamentally different execution environments:
+
+- `.github/workflows/Epic5-CI.yml` remains offline and runs on GitHub-hosted
+  workers without University of Bern credentials or network access.
+- `.github/workflows/tei-live-release.yml` is manual-only and targets a runner
+  carrying all three labels `self-hosted`, `linux`, and `outremer-tei` inside the
+  university network.
+
+The live workflow is inert until an infrastructure owner registers that runner,
+creates protected `tei-staging` and `tei-production` GitHub environments, and
+sets the environment variables below. Production must require human approval.
+This repository contains no runner registration token or service credential.
+
+## Required host/environment configuration
+
+Both environments define non-secret GitHub environment variables:
+
+- `OUTREMER_ENV_FILE`: absolute host path to the root-owned runtime environment;
+- `OUTREMER_LIVE_CONFIG`: absolute host path to the reviewed capability config;
+- `OUTREMER_RELEASE_ROOT`: production immutable release root (production environment);
+- `OUTREMER_PRODUCTION_SMOKE_URL`: production URL including trailing slash.
+
+The staging environment file supplies capability credentials/model names and:
+
+- `OUTREMER_SOURCE_DIR`, `OUTREMER_STATE_DIR`, `OUTREMER_STAGING_DIR`;
+- `OUTREMER_STAGING_SMOKE_URL`, including its trailing slash;
+- GPUStack, ATR, and any enabled MCP/QLever/Voyant endpoint settings.
+
+Start from `deploy/tei/live-capabilities.example.json`, store the resolved copy
+outside the checkout, and review every `required` classification. Optional
+services are recorded as unavailable but do not fail preflight. Required service
+or storage failures block the release.
+
+The runner identity needs no general sudo access. Permit only restart of the
+named staging/production web units. It needs write access to its staging/release
+roots and `/var/lock/outremer-release.lock`; pipeline and deployment identities
+should remain separate where the host policy permits.
+
+## Validation and provenance gates
+
+One `validate` or `promote` dispatch performs, under a non-blocking host `flock`:
+
+1. capability health/model discovery and storage/schema preflight;
+2. a live text-layer run using GPUStack;
+3. a live image-only scan run using the configured recognition backend;
+4. strict run-report gates requiring all documents to succeed, `gpustack` as
+   the only extraction engine, zero fallback chunks, the resolved extraction
+   model, and a recorded recognition engine for the scan;
+5. immutable manifest creation and staging release installation in a run-specific root;
+6. atomic staging pointer switch and smoke checks for representative assets.
+
+The manifest records commit/tree, optional image digest, lock-file digest,
+installed dependency versions, Python version, resolved role models, sanitized
+endpoints, capability/model versions, evidence schema/migration state, and
+digests plus gate results for both live reports. Secret-like keys are forbidden,
+credentials never enter the result, and a dirty tracked checkout cannot produce
+a manifest.
+
+`scripts/release_control.py` can be run manually for diagnosis:
+
+```bash
+python scripts/release_control.py preflight \
+  --config /etc/outremer/live-capabilities.json \
+  --output /var/lib/outremer/staging/preflight.json
+
+python scripts/release_control.py gate \
+  --report data/staging/run_report.json \
+  --expected-model "$EXTRACTION_MODEL" \
+  --require-recognition \
+  --output /var/lib/outremer/staging/gate.json
+```
+
+These reports may contain internal endpoint topology. Keep them on university
+storage; the workflow deliberately does not upload them as GitHub artifacts.
+
+## Promotion
+
+Choosing `promote` first completes all staging validation. Only then does the
+`tei-production` job become eligible for its human approval. It verifies that
+the exact staged directory name matches the checked-out 40-character commit,
+copies that immutable release if necessary, atomically switches `current`,
+records a digest-linked JSONL history event, restarts the named web unit, and
+smoke-tests `index.html` and `app.js`.
+
+The workflow concurrency group never cancels an in-progress run. The same host
+lock prevents overlap with manual/scheduled pipeline work. Operators must make
+other pipeline entry points use `/var/lock/outremer-release.lock` as well.
+
+## Rollback
+
+Rollback is a separate `rollback` dispatch and always crosses the protected
+production environment. Supply a full 40-character commit for a previously
+verified release already present beneath `RELEASE_ROOT/releases/`. The helper
+rejects arbitrary paths, missing/dirty/non-production manifests, or a directory
+whose name differs from its manifested commit. It atomically switches `current`,
+appends the history event, restarts the web service, and smoke-tests it.
+
+This is application rollback. If a future release changes mutable-state schema,
+the state compatibility and restore procedure from #111/#114 must run before an
+older application is selected.
+
+## Failure semantics
+
+- No required backend, model, schema, or writable storage: stop before inference.
+- Heuristic/mixed extraction, fallback chunks, failed/empty documents, wrong
+  model, or missing scan recognition: stop before manifest and promotion.
+- Staging smoke failure: keep the release for diagnosis; do not expose production.
+- Production smoke failure: the job fails visibly; use the protected rollback
+  action rather than silently switching state inside the failing job.
+- Lock contention: stop immediately rather than cancel or overlap expensive work.
+
+Issue #115 adds monitoring and periodic synthetic checks. Issue #85 adds the
+complementary allowed-network/air-gap assertion.

--- a/scripts/promote_release.py
+++ b/scripts/promote_release.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Atomically promote or roll back a verified Outremer release directory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class PromotionError(RuntimeError):
+    pass
+
+
+def resolve_release(release_root: Path, release: Path) -> Path:
+    root = release_root.resolve()
+    releases = (root / "releases").resolve()
+    candidate = release.resolve()
+    if candidate.parent != releases or not candidate.is_dir():
+        raise PromotionError("release must be an existing direct child of RELEASE_ROOT/releases")
+    if not (candidate / "release-manifest.json").is_file():
+        raise PromotionError("release has no release-manifest.json")
+    manifest = json.loads((candidate / "release-manifest.json").read_text())
+    if manifest.get("profile") != "tei-production" or manifest.get("source", {}).get("dirty"):
+        raise PromotionError("release manifest is not a clean tei-production manifest")
+    if manifest.get("source", {}).get("commit") != candidate.name:
+        raise PromotionError("release directory name must equal the manifested commit")
+    return candidate
+
+
+def current_target(release_root: Path) -> str | None:
+    current = release_root / "current"
+    return str(current.resolve()) if current.is_symlink() and current.exists() else None
+
+
+def switch(release_root: Path, release: Path, history: Path, action: str) -> dict:
+    release_root = release_root.resolve()
+    candidate = resolve_release(release_root, release)
+    previous = current_target(release_root)
+    release_root.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=".current-", dir=release_root)
+    os.close(fd)
+    temporary = Path(temporary_name)
+    temporary.unlink()
+    temporary.symlink_to(candidate)
+    os.replace(temporary, release_root / "current")
+    event = {
+        "action": action,
+        "at": datetime.now(timezone.utc).isoformat(),
+        "from": previous,
+        "to": str(candidate),
+        "manifest_sha256": __import__("hashlib").sha256(
+            (candidate / "release-manifest.json").read_bytes()
+        ).hexdigest(),
+    }
+    history.parent.mkdir(parents=True, exist_ok=True)
+    with history.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(event, sort_keys=True) + "\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    return event
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=["promote", "rollback"])
+    parser.add_argument("--release-root", type=Path, required=True)
+    parser.add_argument("--release", type=Path, required=True)
+    parser.add_argument("--history", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        print(json.dumps(switch(args.release_root, args.release, args.history, args.action)))
+    except (PromotionError, OSError, json.JSONDecodeError) as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_control.py
+++ b/scripts/release_control.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Preflight, provenance gate, and immutable manifest for tei releases."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SECRET_MARKERS = ("key", "token", "password", "secret", "credential")
+ALLOWED_CAPABILITY_KINDS = {"http", "http_json", "openai_models", "atr"}
+
+
+class ReleaseControlError(RuntimeError):
+    """A release control rejected configuration, provenance, or promotion."""
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ReleaseControlError(f"{path}: expected a JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def safe_endpoint(raw: str) -> str:
+    """Return a credential-free endpoint or reject unsafe endpoint syntax."""
+    parsed = urllib.parse.urlsplit(raw.rstrip("/"))
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ReleaseControlError("endpoint must be an HTTP(S) URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ReleaseControlError("endpoint must not contain credentials, query, or fragment")
+    host = parsed.hostname
+    if ":" in host:
+        host = f"[{host}]"
+    port = f":{parsed.port}" if parsed.port else ""
+    return urllib.parse.urlunsplit((parsed.scheme, f"{host}{port}", parsed.path, "", ""))
+
+
+def join_url(base: str, path: str) -> str:
+    return f"{base.rstrip('/')}/{path.lstrip('/')}"
+
+
+def auth_headers(capability: dict[str, Any], environ: dict[str, str]) -> dict[str, str]:
+    mode = capability.get("auth", "none")
+    credential_name = capability.get("credential_env")
+    credential = environ.get(credential_name, "") if credential_name else ""
+    if mode in {"bearer", "x-api-key"} and not credential:
+        raise ReleaseControlError(f"{capability['id']}: missing {credential_name}")
+    if mode == "bearer" or (mode == "bearer-optional" and credential):
+        return {"Authorization": f"Bearer {credential}"}
+    if mode == "x-api-key":
+        return {"X-API-Key": credential}
+    if mode not in {"none", "bearer-optional"}:
+        raise ReleaseControlError(f"{capability['id']}: unsupported auth mode {mode}")
+    return {}
+
+
+def request(
+    url: str, headers: dict[str, str], timeout: float, *, expect_json: bool
+) -> tuple[int, Any, dict[str, str]]:
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = response.read(2 * 1024 * 1024)
+            payload = json.loads(body) if expect_json else None
+            return response.status, payload, dict(response.headers.items())
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise ReleaseControlError(f"request failed for {safe_endpoint(url)}: {exc}") from exc
+
+
+def extract_version(payload: Any, headers: dict[str, str]) -> str | None:
+    if isinstance(payload, dict):
+        for key in ("version", "service_version", "api_version"):
+            if payload.get(key) is not None:
+                return str(payload[key])
+    for key in ("X-Service-Version", "X-API-Version"):
+        if headers.get(key):
+            return headers[key]
+    return None
+
+
+def model_ids(payload: Any) -> set[str]:
+    if not isinstance(payload, dict):
+        return set()
+    raw = payload.get("data", payload.get("models", []))
+    if not isinstance(raw, list):
+        return set()
+    return {
+        str(item.get("id") or item.get("name"))
+        for item in raw
+        if isinstance(item, dict) and (item.get("id") or item.get("name"))
+    }
+
+
+def check_capability(
+    capability: dict[str, Any], environ: dict[str, str]
+) -> dict[str, Any]:
+    cap_id = str(capability.get("id") or "")
+    kind = capability.get("kind")
+    if not cap_id or kind not in ALLOWED_CAPABILITY_KINDS:
+        raise ReleaseControlError(f"invalid capability declaration: {capability!r}")
+    url_env = str(capability.get("url_env") or "")
+    raw_url = environ.get(url_env, "")
+    if not raw_url:
+        raise ReleaseControlError(f"{cap_id}: missing {url_env}")
+    endpoint = safe_endpoint(raw_url)
+    headers = auth_headers(capability, environ)
+    timeout = float(capability.get("timeout_seconds", 10))
+    health_path = str(capability.get("health_path", "/"))
+    expect_json = kind in {"http_json", "openai_models", "atr"}
+    status, payload, response_headers = request(
+        join_url(endpoint, health_path), headers, timeout, expect_json=expect_json
+    )
+    if status < 200 or status >= 400:
+        raise ReleaseControlError(f"{cap_id}: health returned HTTP {status}")
+
+    models: set[str] = model_ids(payload) if kind == "openai_models" else set()
+    if kind == "atr":
+        models_path = str(capability.get("models_path", "/models"))
+        _, models_payload, model_headers = request(
+            join_url(endpoint, models_path), headers, timeout, expect_json=True
+        )
+        models = model_ids(models_payload)
+        response_headers.update(model_headers)
+    required_model_envs = capability.get("required_model_envs", [])
+    missing_model_envs = [name for name in required_model_envs if not environ.get(name)]
+    if missing_model_envs:
+        raise ReleaseControlError(
+            f"{cap_id}: required model environment value(s) missing: {missing_model_envs}"
+        )
+    required_models = {environ[name] for name in required_model_envs}
+    missing_models = sorted(required_models - models)
+    if missing_models:
+        raise ReleaseControlError(f"{cap_id}: required model(s) missing: {missing_models}")
+    return {
+        "id": cap_id,
+        "required": bool(capability.get("required")),
+        "status": "available",
+        "endpoint": endpoint,
+        "version": extract_version(payload, response_headers),
+        "models": sorted(models),
+    }
+
+
+def check_storage(item: dict[str, Any], environ: dict[str, str]) -> dict[str, Any]:
+    path_env = str(item.get("path_env") or "")
+    value = environ.get(path_env, "")
+    if not value:
+        raise ReleaseControlError(f"{item.get('id')}: missing {path_env}")
+    path = Path(value)
+    if not path.is_absolute() or ".." in path.parts or path == Path("/"):
+        raise ReleaseControlError(f"{item.get('id')}: unsafe storage path")
+    if not path.is_dir():
+        raise ReleaseControlError(f"{item.get('id')}: storage directory does not exist")
+    if not os.access(path, os.R_OK | os.X_OK):
+        raise ReleaseControlError(f"{item.get('id')}: storage directory is not readable")
+    if item.get("writable") and not os.access(path, os.W_OK):
+        raise ReleaseControlError(f"{item.get('id')}: storage directory is not writable")
+    return {
+        "id": str(item.get("id")),
+        "path": str(path),
+        "writable": bool(item.get("writable")),
+        "status": "available",
+    }
+
+
+def preflight(config: dict[str, Any], environ: dict[str, str]) -> dict[str, Any]:
+    if config.get("schema_version") != 1:
+        raise ReleaseControlError("unsupported live-capabilities schema")
+    results: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for capability in config.get("capabilities", []):
+        try:
+            results.append(check_capability(capability, environ))
+        except ReleaseControlError as exc:
+            result = {
+                "id": str(capability.get("id")),
+                "required": bool(capability.get("required")),
+                "status": "unavailable",
+                "error": str(exc),
+            }
+            results.append(result)
+            if result["required"]:
+                errors.append(str(exc))
+    storage_results: list[dict[str, Any]] = []
+    for item in config.get("storage", []):
+        try:
+            storage_results.append(check_storage(item, environ))
+        except ReleaseControlError as exc:
+            storage_results.append({"id": item.get("id"), "status": "unavailable", "error": str(exc)})
+            errors.append(str(exc))
+
+    try:
+        from evidence_model import SCHEMA_VERSION
+    except ImportError:
+        from scripts.evidence_model import SCHEMA_VERSION
+    expected_schema = str((config.get("schema") or {}).get("evidence") or "")
+    if expected_schema != SCHEMA_VERSION:
+        errors.append(
+            f"evidence schema mismatch: config={expected_schema!r}, code={SCHEMA_VERSION!r}"
+        )
+    return {
+        "schema_version": 1,
+        "checked_at": now(),
+        "profile": config.get("profile"),
+        "status": "pass" if not errors else "fail",
+        "capabilities": results,
+        "storage": storage_results,
+        "schemas": {"evidence": SCHEMA_VERSION},
+        "errors": errors,
+    }
+
+
+def gate_report(
+    report: dict[str, Any], *, require_recognition: bool, expected_model: str | None
+) -> dict[str, Any]:
+    errors: list[str] = []
+    docs_total = int(report.get("docs_total", 0))
+    docs_ok = int(report.get("docs_ok", 0))
+    docs_failed = int(report.get("docs_failed", 0))
+    if docs_total < 1 or docs_ok != docs_total or docs_failed:
+        errors.append(
+            f"document outcome is not publication-grade: total={docs_total}, ok={docs_ok}, failed={docs_failed}"
+        )
+    by_engine = (report.get("extraction") or {}).get("documents_by_engine") or {}
+    unexpected = sorted(engine for engine, count in by_engine.items() if count and engine != "gpustack")
+    if unexpected or not by_engine or sum(by_engine.values()) != docs_total:
+        errors.append(f"unexpected extraction engines: {by_engine!r}")
+    if report.get("llm_provider") != "gpustack":
+        errors.append(f"llm_provider must be gpustack, got {report.get('llm_provider')!r}")
+    degradation = (report.get("extraction") or {}).get("degradation") or {}
+    if int(degradation.get("fallback_chunks", 0)):
+        errors.append(f"fallback chunks are forbidden: {degradation!r}")
+    if expected_model and report.get("extraction_model") != expected_model:
+        errors.append(
+            f"extraction model mismatch: expected {expected_model!r}, got {report.get('extraction_model')!r}"
+        )
+    recognition = (report.get("recognition") or {}).get("engines_used") or {}
+    if require_recognition and not any(int(count) > 0 for count in recognition.values()):
+        errors.append("representative scanned fixture did not record a recognition engine")
+    if report.get("failures"):
+        errors.append("run report contains failures")
+    return {
+        "schema_version": 1,
+        "checked_at": now(),
+        "status": "pass" if not errors else "fail",
+        "require_recognition": require_recognition,
+        "observed": {
+            "documents_by_engine": by_engine,
+            "recognition_engines": recognition,
+            "extraction_model": report.get("extraction_model"),
+        },
+        "errors": errors,
+    }
+
+
+def git_value(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def dependency_versions() -> dict[str, str]:
+    result: dict[str, str] = {}
+    for dist in importlib.metadata.distributions():
+        name = dist.metadata.get("Name")
+        if name:
+            result[name.casefold()] = dist.version
+    return dict(sorted(result.items()))
+
+
+def assert_no_secret_keys(value: Any, path: str = "manifest") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lowered = str(key).casefold()
+            if any(marker in lowered for marker in SECRET_MARKERS):
+                raise ReleaseControlError(f"secret-like key forbidden in manifest: {path}.{key}")
+            assert_no_secret_keys(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            assert_no_secret_keys(child, f"{path}[{index}]")
+
+
+def build_manifest(
+    preflight_result: dict[str, Any], reports: list[Path], image_digest: str | None
+) -> dict[str, Any]:
+    if preflight_result.get("status") != "pass":
+        raise ReleaseControlError("cannot manifest a failed preflight")
+    if image_digest and not image_digest.startswith("sha256:"):
+        raise ReleaseControlError("image digest must use sha256:<hex>")
+    lock = Path("requirements.lock.txt")
+    report_entries = [
+        {"path": str(path), "sha256": sha256_file(path), "gate": gate_report(read_json(path), require_recognition=False, expected_model=None)}
+        for path in reports
+    ]
+    if any(entry["gate"]["status"] != "pass" for entry in report_entries):
+        raise ReleaseControlError("cannot manifest a run report that fails the provenance gate")
+    capabilities = [
+        {
+            key: capability.get(key)
+            for key in ("id", "status", "endpoint", "version", "models")
+            if capability.get(key) is not None
+        }
+        for capability in preflight_result.get("capabilities", [])
+    ]
+    manifest = {
+        "schema_version": 1,
+        "created_at": now(),
+        "profile": preflight_result.get("profile"),
+        "source": {
+            "commit": git_value("rev-parse", "HEAD"),
+            "tree": git_value("rev-parse", "HEAD^{tree}"),
+            "dirty": bool(git_value("status", "--porcelain", "--untracked-files=no")),
+        },
+        "artifact": {"image_digest": image_digest},
+        "runtime": {"python": platform.python_version()},
+        "dependencies": {
+            "lock_sha256": sha256_file(lock),
+            "installed": dependency_versions(),
+        },
+        "models": {
+            "text": os.environ.get("GPUSTACK_MODEL_TEXT") or os.environ.get("EXTRACTION_MODEL"),
+            "vision": os.environ.get("GPUSTACK_MODEL_VISION") or os.environ.get("QWEN3_VL_MODEL"),
+            "orchestrator": os.environ.get("GPUSTACK_MODEL_ORCHESTRATOR") or os.environ.get("ORCHESTRATOR_MODEL"),
+        },
+        "capabilities": capabilities,
+        "schemas": preflight_result.get("schemas", {}),
+        "migrations": {"status": "validated", "evidence_schema": preflight_result.get("schemas", {}).get("evidence")},
+        "run_reports": report_entries,
+    }
+    if manifest["source"]["dirty"]:
+        raise ReleaseControlError("release manifest requires a clean checkout")
+    assert_no_secret_keys(manifest)
+    return manifest
+
+
+def command_preflight(args: argparse.Namespace) -> int:
+    result = preflight(read_json(args.config), dict(os.environ))
+    write_json(args.output, result)
+    if result["status"] != "pass":
+        for error in result["errors"]:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def command_gate(args: argparse.Namespace) -> int:
+    result = gate_report(
+        read_json(args.report),
+        require_recognition=args.require_recognition,
+        expected_model=args.expected_model,
+    )
+    write_json(args.output, result)
+    if result["status"] != "pass":
+        for error in result["errors"]:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def command_manifest(args: argparse.Namespace) -> int:
+    manifest = build_manifest(read_json(args.preflight), args.report, args.image_digest)
+    write_json(args.output, manifest)
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(required=True)
+    preflight_parser = commands.add_parser("preflight")
+    preflight_parser.add_argument("--config", type=Path, required=True)
+    preflight_parser.add_argument("--output", type=Path, required=True)
+    preflight_parser.set_defaults(func=command_preflight)
+    gate_parser = commands.add_parser("gate")
+    gate_parser.add_argument("--report", type=Path, required=True)
+    gate_parser.add_argument("--output", type=Path, required=True)
+    gate_parser.add_argument("--require-recognition", action="store_true")
+    gate_parser.add_argument("--expected-model")
+    gate_parser.set_defaults(func=command_gate)
+    manifest_parser = commands.add_parser("manifest")
+    manifest_parser.add_argument("--preflight", type=Path, required=True)
+    manifest_parser.add_argument("--report", type=Path, action="append", required=True)
+    manifest_parser.add_argument("--image-digest")
+    manifest_parser.add_argument("--output", type=Path, required=True)
+    manifest_parser.set_defaults(func=command_manifest)
+    return root
+
+
+def main() -> int:
+    try:
+        args = parser().parse_args()
+        return int(args.func(args))
+    except (ReleaseControlError, OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_control.py
+++ b/tests/test_release_control.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import promote_release, release_control
+
+
+def good_report(*, recognition: bool = False) -> dict:
+    return {
+        "docs_total": 1,
+        "docs_ok": 1,
+        "docs_failed": 0,
+        "llm_provider": "gpustack",
+        "extraction_model": "text-model",
+        "failures": [],
+        "extraction": {
+            "documents_by_engine": {"gpustack": 1},
+            "degradation": {"chunks": 1, "fallback_chunks": 0, "reasons": []},
+        },
+        "recognition": {"engines_used": {"qwen3-vl": 1} if recognition else {}},
+    }
+
+
+def test_gate_accepts_text_and_scanned_production_runs() -> None:
+    text = release_control.gate_report(
+        good_report(), require_recognition=False, expected_model="text-model"
+    )
+    scan = release_control.gate_report(
+        good_report(recognition=True),
+        require_recognition=True,
+        expected_model="text-model",
+    )
+    assert text["status"] == "pass"
+    assert scan["status"] == "pass"
+
+
+@pytest.mark.parametrize(
+    "mutation,error",
+    [
+        (lambda r: r.update(llm_provider="heuristic"), "llm_provider"),
+        (
+            lambda r: r["extraction"].update(documents_by_engine={"mixed": 1}),
+            "unexpected extraction engines",
+        ),
+        (
+            lambda r: r["extraction"]["degradation"].update(fallback_chunks=1),
+            "fallback chunks",
+        ),
+        (lambda r: r.update(docs_failed=1, docs_ok=0), "document outcome"),
+        (lambda r: r.update(extraction_model="wrong"), "model mismatch"),
+    ],
+)
+def test_gate_rejects_non_production_provenance(mutation, error: str) -> None:
+    report = good_report()
+    mutation(report)
+    result = release_control.gate_report(
+        report, require_recognition=False, expected_model="text-model"
+    )
+    assert result["status"] == "fail"
+    assert any(error in item for item in result["errors"])
+
+
+def test_gate_requires_recognition_for_scanned_fixture() -> None:
+    result = release_control.gate_report(
+        good_report(), require_recognition=True, expected_model="text-model"
+    )
+    assert result["status"] == "fail"
+    assert "recognition engine" in result["errors"][0]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:pass@example.org/v1",
+        "https://example.org/v1?token=x",
+        "ftp://example.org/v1",
+        "not-a-url",
+    ],
+)
+def test_safe_endpoint_rejects_secrets_and_unsupported_urls(url: str) -> None:
+    with pytest.raises(release_control.ReleaseControlError):
+        release_control.safe_endpoint(url)
+
+
+def test_preflight_records_optional_failure_but_passes(monkeypatch, tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    state = tmp_path / "state"
+    staging = tmp_path / "staging"
+    for path in (source, state, staging):
+        path.mkdir()
+    config = {
+        "schema_version": 1,
+        "profile": "tei-production",
+        "capabilities": [
+            {"id": "required", "required": True, "kind": "http", "url_env": "REQ"},
+            {"id": "optional", "required": False, "kind": "http", "url_env": "OPT"},
+        ],
+        "storage": [
+            {"id": "source", "path_env": "SOURCE", "writable": False},
+            {"id": "state", "path_env": "STATE", "writable": True},
+            {"id": "staging", "path_env": "STAGING", "writable": True},
+        ],
+        "schema": {"evidence": "1.0.0"},
+    }
+
+    def fake_check(capability, _environ):
+        if capability["id"] == "optional":
+            raise release_control.ReleaseControlError("optional unavailable")
+        return {"id": "required", "required": True, "status": "available"}
+
+    monkeypatch.setattr(release_control, "check_capability", fake_check)
+    result = release_control.preflight(
+        config,
+        {
+            "REQ": "https://required.test",
+            "OPT": "https://optional.test",
+            "SOURCE": str(source),
+            "STATE": str(state),
+            "STAGING": str(staging),
+        },
+    )
+    assert result["status"] == "pass"
+    assert result["capabilities"][1]["status"] == "unavailable"
+
+
+def test_required_preflight_failure_blocks(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        release_control,
+        "check_capability",
+        lambda *_: (_ for _ in ()).throw(release_control.ReleaseControlError("down")),
+    )
+    result = release_control.preflight(
+        {
+            "schema_version": 1,
+            "profile": "tei-production",
+            "capabilities": [{"id": "required", "required": True, "kind": "http"}],
+            "storage": [],
+            "schema": {"evidence": "1.0.0"},
+        },
+        {},
+    )
+    assert result["status"] == "fail"
+    assert result["errors"] == ["down"]
+
+
+def manifest(commit: str) -> dict:
+    return {"profile": "tei-production", "source": {"commit": commit, "dirty": False}}
+
+
+def make_release(root: Path, commit: str) -> Path:
+    release = root / "releases" / commit
+    release.mkdir(parents=True)
+    (release / "release-manifest.json").write_text(json.dumps(manifest(commit)))
+    return release
+
+
+def test_promotion_and_rollback_are_atomic_and_audited(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    first = make_release(root, "a" * 40)
+    second = make_release(root, "b" * 40)
+    history = root / "history.jsonl"
+
+    promoted = promote_release.switch(root, first, history, "promote")
+    rolled = promote_release.switch(root, second, history, "rollback")
+
+    assert (root / "current").resolve() == second
+    assert promoted["from"] is None
+    assert rolled["from"] == str(first)
+    events = [json.loads(line) for line in history.read_text().splitlines()]
+    assert [event["action"] for event in events] == ["promote", "rollback"]
+    assert all(len(event["manifest_sha256"]) == 64 for event in events)
+
+
+def test_promotion_rejects_arbitrary_path_and_commit_mismatch(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "release-manifest.json").write_text(json.dumps(manifest("a" * 40)))
+    with pytest.raises(promote_release.PromotionError):
+        promote_release.resolve_release(root, outside)
+
+    mismatch = make_release(root, "a" * 40)
+    (mismatch / "release-manifest.json").write_text(json.dumps(manifest("b" * 40)))
+    with pytest.raises(promote_release.PromotionError, match="directory name"):
+        promote_release.resolve_release(root, mismatch)
+
+
+def test_manifest_secret_key_guard() -> None:
+    with pytest.raises(release_control.ReleaseControlError, match="secret-like"):
+        release_control.assert_no_secret_keys({"nested": {"api_token": "value"}})
+
+
+def test_manifest_records_reproducibility_without_credentials(monkeypatch, tmp_path: Path) -> None:
+    report = tmp_path / "run-report.json"
+    report.write_text(json.dumps(good_report()))
+    monkeypatch.setattr(
+        release_control,
+        "git_value",
+        lambda *args: "" if args[0] == "status" else ("a" * 40 if args[-1] == "HEAD" else "b" * 40),
+    )
+    monkeypatch.setattr(release_control, "dependency_versions", lambda: {"example": "1.2.3"})
+    monkeypatch.setenv("EXTRACTION_MODEL", "text-model")
+    monkeypatch.setenv("QWEN3_VL_MODEL", "vision-model")
+    monkeypatch.setenv("ORCHESTRATOR_MODEL", "orch-model")
+    result = release_control.build_manifest(
+        {
+            "status": "pass",
+            "profile": "tei-production",
+            "schemas": {"evidence": "1.0.0"},
+            "capabilities": [
+                {
+                    "id": "gpustack",
+                    "status": "available",
+                    "endpoint": "https://gpustack.example/v1",
+                    "version": "1",
+                    "models": ["text-model"],
+                }
+            ],
+        },
+        [report],
+        "sha256:" + "c" * 64,
+    )
+    assert result["source"]["commit"] == "a" * 40
+    assert result["dependencies"]["lock_sha256"]
+    assert result["models"] == {
+        "text": "text-model",
+        "vision": "vision-model",
+        "orchestrator": "orch-model",
+    }
+    assert "GPUSTACK_API_KEY" not in json.dumps(result)
+
+
+def test_live_workflow_is_manual_inside_network_and_non_cancelling() -> None:
+    workflow = (Path(__file__).parents[1] / ".github/workflows/tei-live-release.yml").read_text()
+    trigger = workflow.split("permissions:", 1)[0]
+    assert "workflow_dispatch:" in trigger
+    assert "schedule:" not in trigger
+    assert "push:" not in trigger
+    assert workflow.count("runs-on: [self-hosted, linux, outremer-tei]") == 3
+    assert "environment: tei-staging" in workflow
+    assert workflow.count("environment: tei-production") == 2
+    assert "cancel-in-progress: false" in workflow
+    assert "flock -n 9" in workflow
+    assert "upload-artifact" not in workflow
+
+
+def test_workflow_removes_transient_report_before_release_copy() -> None:
+    workflow = (Path(__file__).parents[1] / ".github/workflows/tei-live-release.yml").read_text()
+    cleanup = workflow.index("rm -f data/staging/run_report.json")
+    copy = workflow.index("rsync -a --delete")
+    assert cleanup < copy


### PR DESCRIPTION
## What changed

- add a manual-only workflow targeting an explicitly labelled inside-network runner
- split live validation from existing offline GitHub CI without adding university credentials to GitHub-hosted jobs
- add declarative preflight for GPUStack models, ATR health/model registry, optional MCP/QLever/Voyant services, storage, and evidence schema
- add a strict provenance gate that rejects heuristic/mixed extraction, fallback chunks, failed/empty runs, wrong models, and missing scan recognition
- generate an immutable release manifest with commit/tree, dependency lock and installed versions, Python, role models, sanitized service/version metadata, schema/migration state, and live report digests/gates
- add host and workflow concurrency control, run-specific staging releases, protected production promotion, atomic symlink switching, audited rollback, and smoke tests
- document runner/environment setup, failure semantics, promotion, and rollback
- add 19 offline release-control tests

## Safety boundaries

- workflow is `workflow_dispatch` only; no push or schedule trigger
- all jobs require `[self-hosted, linux, outremer-tei]`
- production promotion/rollback cross the protected `tei-production` environment
- no service credential or resolved internal configuration is committed or uploaded as a GitHub artifact
- no production action runs as part of this PR
- branch is directly from `origin/main`, not stacked on #117 or #118

## Verification

- `pytest -q tests/test_release_control.py` — 19 passed
- `ruff check scripts/release_control.py scripts/promote_release.py tests/test_release_control.py`
- JSON/YAML parse checks
- `git diff --check`
- negative CLI/path/provenance/secret tests

## Remaining operational acceptance

This PR intentionally does **not** close #112. After merge, an infrastructure owner must register/configure the protected university runner and execute the first live staging run proving GPUStack extraction and scanned recognition. The issue should close only after that run and its manifest are reviewed.

Part of #112
