### PR TITLE
Add the shared capability adapter layer

### DIFF
--- a/docs/CAPABILITY_ADAPTERS.md
+++ b/docs/CAPABILITY_ADAPTERS.md
@@ -1,0 +1,107 @@
+# Shared research capability adapters
+
+Outremer integrates University of Bern services through provider-neutral
+contracts in `scripts/capabilities/`. It does not import the
+`agentic_historian` Discord bot, orchestration, deployment state, or
+repository-relative application modules. Service differences are contained in
+anti-corruption adapters; Outremer evidence, authority candidates, evaluation,
+and review decisions remain canonical.
+
+## Registry contract
+
+Every adapter publishes:
+
+- stable capability, provider, contract and contract-version identifiers;
+- required/optional and enabled/disabled policy;
+- typed tool descriptors with input/output schemas and mutation markers;
+- discovery output with availability, sanitized endpoint, provider version and
+  discovered tools;
+- a single `invoke(tool_id, arguments)` boundary.
+
+`CapabilityRegistry.discover()` makes partial failure visible. A missing optional
+provider reports `unavailable` or `disabled` without changing canonical data. A
+missing required provider makes the report fail and `require_ready()` blocks the
+job. Invocation is blocked unless the provider was discovered as available.
+
+Invocation provenance is append-only JSONL. It records run/invocation/tool and
+contract identifiers, provider version, timing, status, error type, and input /
+output artifact references with SHA-256 digests. It never records arguments,
+responses, source text, or credentials; secret-like keys are rejected.
+The registry fails closed on invocation when no audit log is configured.
+
+## Adapters
+
+- **GPUStack:** OpenAI-compatible model discovery, role-routed text/vision,
+  embeddings and reranking. It accepts `GPUSTACK_MODEL_*` roles with current
+  direct-name variables as compatibility fallbacks until #88 merges.
+- **ATR:** health/models, segmentation and attributed recognition/OCR. This is a
+  thin shim around the current Outremer `AtrClient`; #87 must replace that import
+  with the selected shared package once #90 decides its ownership/versioning.
+- **MCP knowledge federation:** streamable-HTTP initialization, tool discovery
+  and tool calls. Person results become *unreviewed external candidates* with
+  source-local identity preserved; they are never merged directly into an
+  Outremer authority record.
+- **QLever:** read-only SPARQL. Update operations are rejected even if hidden
+  behind `PREFIX`/`BASE` declarations.
+- **Voyant:** explicit, mutating corpus hand-off of approved non-empty text.
+- **Remote agent tools:** provider-neutral `/tools` discovery and `/invoke` for
+  source description, entity, corpus-analysis or reporting contracts that pass
+  scholarly-fit review. The adapter does not assume Agent A–E module paths.
+
+## Feature flags
+
+GPUStack is required. Other providers are off unless enabled:
+
+```env
+OUTREMER_CAPABILITY_ATR=true
+OUTREMER_CAPABILITY_ATR_REQUIRED=false
+OUTREMER_CAPABILITY_MCP=false
+OUTREMER_CAPABILITY_QLEVER=false
+OUTREMER_CAPABILITY_VOYANT=false
+OUTREMER_CAPABILITY_AGENT_TOOLS=false
+```
+
+Endpoints and credentials retain their service-specific variables:
+`GPUSTACK_BASE_URL`, `GPUSTACK_API_KEY`, `ATR_GATEWAY_URL`, `ATR_API_KEY`,
+`MCP_BASE_URL`, `MCP_API_KEY`, `QLEVER_ENDPOINT`, `VOYANT_API_URL`, and
+`OUTREMER_TOOL_PROVIDER_URL`. Reports contain endpoint URLs but never keys.
+
+## Startup discovery
+
+```bash
+python scripts/discover_capabilities.py \
+  --output data/staging/capability-availability.json \
+  --invocation-log data/staging/capability-invocations.jsonl \
+  --require-ready
+```
+
+Services should run discovery before accepting a job. The production preflight
+in #112 can consume this report after both PRs merge.
+
+## Live staging smoke test
+
+The safe smoke command performs discovery only: GPUStack model listing, ATR
+health/model listing, MCP initialization/tool listing, QLever `ASK`, and a
+Voyant landing-page request. It does not publish, update the graph, hand off a
+corpus, or invoke a remote agent tool.
+
+```bash
+python scripts/capability_smoke.py \
+  --require gpustack,atr,mcp,qlever,voyant \
+  --output /var/lib/outremer/staging/capability-smoke.json
+```
+
+`tests/test_capability_adapters.py` contains an opt-in equivalent marked
+`live_backend`; set `OUTREMER_LIVE_CAPABILITY_SMOKE=1` only on the protected
+university runner. Offline CI mocks every transport boundary.
+
+## Open dependency boundary
+
+This implementation cannot complete #113 by itself:
+
+1. #90 must select and document package/service ownership.
+2. #87 must publish the shared ATR client and remove the private-client shim.
+3. The protected university staging run must exercise GPUStack, ATR, one MCP
+   source, QLever and Voyant and retain its availability report.
+
+Until those conditions hold, #113 stays open even if this adapter PR merges.

--- a/scripts/capabilities/__init__.py
+++ b/scripts/capabilities/__init__.py
@@ -1,0 +1,21 @@
+"""Provider-neutral capability adapters for Outremer."""
+
+from .contracts import (
+    ArtifactRef,
+    Availability,
+    CapabilityDescriptor,
+    CapabilityError,
+    InvocationRecord,
+    ToolSpec,
+)
+from .registry import CapabilityRegistry
+
+__all__ = [
+    "ArtifactRef",
+    "Availability",
+    "CapabilityDescriptor",
+    "CapabilityError",
+    "CapabilityRegistry",
+    "InvocationRecord",
+    "ToolSpec",
+]

--- a/scripts/capabilities/adapters.py
+++ b/scripts/capabilities/adapters.py
@@ -1,0 +1,480 @@
+"""Anti-corruption adapters for the shared agentic-historian service stack."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.parse
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from .contracts import Availability, CapabilityDescriptor, CapabilityError, ToolSpec
+
+Transport = Callable[..., httpx.Response]
+
+
+def checked_endpoint(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value.rstrip("/"))
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise CapabilityError("endpoint must be an HTTP(S) URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise CapabilityError("endpoint cannot contain credentials, query, or fragment")
+    return value.rstrip("/")
+
+
+def checked(response: httpx.Response) -> httpx.Response:
+    try:
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise CapabilityError(f"provider returned HTTP {response.status_code}") from exc
+    return response
+
+
+def version(payload: Any, response: httpx.Response) -> str | None:
+    if isinstance(payload, dict):
+        for key in ("version", "service_version", "api_version"):
+            if payload.get(key) is not None:
+                return str(payload[key])
+    return response.headers.get("X-Service-Version") or response.headers.get("X-API-Version")
+
+
+def model_ids(payload: dict[str, Any]) -> set[str]:
+    values = payload.get("data", payload.get("models", []))
+    return {
+        str(item.get("id") or item.get("name"))
+        for item in values
+        if isinstance(item, dict) and (item.get("id") or item.get("name"))
+    }
+
+
+class HttpAdapter:
+    def __init__(self, endpoint: str, *, timeout: float = 30, transport: Transport | None = None) -> None:
+        self.endpoint = checked_endpoint(endpoint) if endpoint else ""
+        self.timeout = timeout
+        self.transport = transport or httpx.request
+
+    def request(self, method: str, path: str = "", **kwargs: Any) -> httpx.Response:
+        if not self.endpoint:
+            raise CapabilityError("endpoint is not configured")
+        return checked(
+            self.transport(method, f"{self.endpoint}/{path.lstrip('/')}", timeout=self.timeout, **kwargs)
+        )
+
+    def availability(
+        self, descriptor: CapabilityDescriptor, response: httpx.Response, payload: Any
+    ) -> Availability:
+        return Availability(
+            descriptor.id,
+            "available",
+            datetime.now(timezone.utc).isoformat(),
+            provider_version=version(payload, response),
+            endpoint=self.endpoint,
+            tools=tuple(tool.id for tool in descriptor.tools),
+        )
+
+
+class GPUStackAdapter(HttpAdapter):
+    CONTRACT_VERSION = "1.0"
+
+    def __init__(
+        self,
+        endpoint: str,
+        api_key: str,
+        models: dict[str, str],
+        *,
+        required: bool = True,
+        enabled: bool = True,
+        timeout: float = 120,
+        transport: Transport | None = None,
+    ) -> None:
+        super().__init__(endpoint, timeout=timeout, transport=transport)
+        self.api_key = api_key
+        self.models = models
+        self.descriptor = CapabilityDescriptor(
+            "gpustack",
+            "unibe-gpustack",
+            "openai-compatible",
+            self.CONTRACT_VERSION,
+            required,
+            enabled,
+            (
+                ToolSpec("text.generate", "Role-routed text generation", {"type": "object"}, {"type": "object"}),
+                ToolSpec("vision.generate", "Role-routed visual generation", {"type": "object"}, {"type": "object"}),
+                ToolSpec("embedding.embed", "Multilingual embeddings", {"type": "object"}, {"type": "object"}),
+                ToolSpec("reranker.rerank", "Multilingual candidate reranking", {"type": "object"}, {"type": "object"}),
+            ),
+        )
+
+    @property
+    def headers(self) -> dict[str, str]:
+        if not self.api_key:
+            raise CapabilityError("GPUStack API key is not configured")
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    def discover(self) -> Availability:
+        missing_roles = sorted(role for role in ("text", "vision", "orchestrator") if not self.models.get(role))
+        if missing_roles:
+            return Availability(
+                self.descriptor.id,
+                "incompatible",
+                datetime.now(timezone.utc).isoformat(),
+                endpoint=self.endpoint,
+                detail=f"missing configured model role(s): {missing_roles}",
+            )
+        response = self.request("GET", "models", headers=self.headers)
+        payload = response.json()
+        available = model_ids(payload)
+        required_models = {value for value in self.models.values() if value}
+        missing = sorted(required_models - available)
+        if missing:
+            return Availability(
+                self.descriptor.id,
+                "incompatible",
+                datetime.now(timezone.utc).isoformat(),
+                endpoint=self.endpoint,
+                detail=f"missing configured models: {missing}",
+            )
+        return self.availability(self.descriptor, response, payload)
+
+    def invoke(self, tool_id: str, arguments: dict[str, Any]) -> Any:
+        role_for_tool = {
+            "text.generate": "text",
+            "vision.generate": "vision",
+            "embedding.embed": "embedding",
+            "reranker.rerank": "reranker",
+        }
+        role = role_for_tool[tool_id]
+        model = self.models.get(role)
+        if not model:
+            raise CapabilityError(f"no model configured for role {role}")
+        if tool_id == "embedding.embed":
+            payload = {"model": model, "input": arguments["input"]}
+            return self.request("POST", "embeddings", headers=self.headers, json=payload).json()
+        if tool_id == "reranker.rerank":
+            payload = {"model": model, **arguments}
+            return self.request("POST", "rerank", headers=self.headers, json=payload).json()
+        payload = {"model": model, **arguments}
+        return self.request("POST", "chat/completions", headers=self.headers, json=payload).json()
+
+
+class ATRAdapter:
+    """Temporary shim; #87 replaces the private client import with the shared package."""
+
+    CONTRACT_VERSION = "1.0"
+
+    def __init__(self, client: Any, *, required: bool = False, enabled: bool = True) -> None:
+        self.client = client
+        self.descriptor = CapabilityDescriptor(
+            "atr",
+            "serving-atr-inference",
+            "atr-gateway",
+            self.CONTRACT_VERSION,
+            required,
+            enabled,
+            (
+                ToolSpec("atr.segment", "Segment a page", {"type": "object"}, {"type": "object"}),
+                ToolSpec("atr.recognize", "Recognize a page", {"type": "object"}, {"type": "object"}),
+                ToolSpec("atr.ocr", "Segment and recognize a page", {"type": "object"}, {"type": "object"}),
+            ),
+        )
+
+    def discover(self) -> Availability:
+        health = self.client.health_check()
+        models = self.client.list_models()
+        return Availability(
+            "atr",
+            "available",
+            datetime.now(timezone.utc).isoformat(),
+            provider_version=str(health.get("version") or "unknown"),
+            endpoint=getattr(self.client, "base_url", None),
+            tools=tuple(tool.id for tool in self.descriptor.tools),
+            detail=f"{len(models)} model(s)",
+        )
+
+    def invoke(self, tool_id: str, arguments: dict[str, Any]) -> Any:
+        if tool_id == "atr.segment":
+            return self.client.segment(arguments["image"], seg_mode=arguments.get("seg_mode", "baseline"))
+        result = self.client.transcribe(
+            arguments["image"],
+            model=arguments["model"],
+            engine=arguments.get("engine", "party" if tool_id == "atr.recognize" else "kraken"),
+            seg_mode=arguments.get("seg_mode", "baseline"),
+        )
+        return {
+            "text": result.text,
+            "confidence": result.confidence,
+            "model": result.model,
+            "engine": result.engine,
+            "service_version": result.service_version,
+        }
+
+
+class MCPAdapter(HttpAdapter):
+    CONTRACT_VERSION = "2024-11-05"
+
+    def __init__(self, endpoint: str, *, api_key: str = "", required: bool = False, enabled: bool = False, transport: Transport | None = None) -> None:
+        super().__init__(endpoint, transport=transport)
+        self.api_key = api_key
+        self.descriptor = CapabilityDescriptor(
+            "mcp",
+            "agentic-historian-knowledge-hub",
+            "mcp-streamable-http",
+            self.CONTRACT_VERSION,
+            required,
+            enabled,
+            (
+                ToolSpec("mcp.person_search", "Federated person search", {"type": "object"}, {"type": "object"}),
+                ToolSpec("mcp.source_description", "Provider source description", {"type": "object"}, {"type": "object"}),
+            ),
+        )
+
+    @staticmethod
+    def _decode(response: httpx.Response) -> dict[str, Any]:
+        if "text/event-stream" in response.headers.get("content-type", ""):
+            for line in response.text.splitlines():
+                if line.startswith("data:"):
+                    return json.loads(line[5:].lstrip())
+            raise CapabilityError("MCP returned an empty event stream")
+        return response.json()
+
+    def _rpc(self, method: str, params: dict[str, Any], rpc_id: int = 2) -> tuple[httpx.Response, dict[str, Any]]:
+        headers = {"Accept": "application/json, text/event-stream", "Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": self.CONTRACT_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "outremer", "version": "0.1"},
+            },
+        }
+        init_response = self.request("POST", "", headers=headers, json=initialize)
+        init_body = self._decode(init_response)
+        if init_body.get("error"):
+            raise CapabilityError(f"MCP initialize error {init_body['error'].get('code')}")
+        session = init_response.headers.get("Mcp-Session-Id")
+        if session:
+            headers["Mcp-Session-Id"] = session
+        self.request(
+            "POST",
+            "",
+            headers=headers,
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        payload = {"jsonrpc": "2.0", "id": rpc_id, "method": method, "params": params}
+        response = self.request("POST", "", headers=headers, json=payload)
+        body = self._decode(response)
+        if body.get("error"):
+            raise CapabilityError(f"MCP error {body['error'].get('code')}")
+        return response, body
+
+    def discover(self) -> Availability:
+        response, payload = self._rpc("tools/list", {})
+        tools = payload.get("result", {}).get("tools", [])
+        return Availability(
+            "mcp",
+            "available",
+            datetime.now(timezone.utc).isoformat(),
+            provider_version=response.headers.get("Mcp-Protocol-Version") or self.CONTRACT_VERSION,
+            endpoint=self.endpoint,
+            tools=tuple(sorted(str(tool.get("name")) for tool in tools if tool.get("name"))),
+        )
+
+    def invoke(self, tool_id: str, arguments: dict[str, Any]) -> Any:
+        remote_name = {"mcp.person_search": "search_persons", "mcp.source_description": "describe_source"}[tool_id]
+        _, payload = self._rpc("tools/call", {"name": remote_name, "arguments": arguments})
+        return payload.get("result")
+
+    @staticmethod
+    def to_outremer_candidates(result: Any) -> list[dict[str, Any]]:
+        """Preserve source identities; never merge them into authority truth."""
+        persons = result.get("persons", []) if isinstance(result, dict) else []
+        candidates = []
+        for person in persons:
+            source = str(person.get("source") or "unknown")
+            pid = str(person.get("pid") or "")
+            if not pid or not person.get("name"):
+                continue
+            candidates.append(
+                {
+                    "candidate_id": f"mcp:{source}:{pid}",
+                    "label": str(person["name"]),
+                    "source": source,
+                    "source_id": pid,
+                    "variants": list(person.get("variants") or []),
+                    "external_ids": {
+                        key: person[key]
+                        for key in ("hls_id", "gnd_id", "wikidata_id")
+                        if person.get(key) is not None
+                    },
+                    "status": "unreviewed",
+                }
+            )
+        return candidates
+
+
+class QLeverAdapter(HttpAdapter):
+    CONTRACT_VERSION = "SPARQL-1.1"
+
+    def __init__(self, endpoint: str, *, required: bool = False, enabled: bool = False, transport: Transport | None = None) -> None:
+        super().__init__(endpoint, transport=transport)
+        self.descriptor = CapabilityDescriptor(
+            "qlever",
+            "qlever",
+            "sparql-query",
+            self.CONTRACT_VERSION,
+            required,
+            enabled,
+            (ToolSpec("graph.query", "Read-only SPARQL query", {"type": "object"}, {"type": "object"}),),
+        )
+
+    def discover(self) -> Availability:
+        response = self.request(
+            "POST", "", data={"query": "ASK { ?s ?p ?o }"}, headers={"Accept": "application/sparql-results+json"}
+        )
+        return self.availability(self.descriptor, response, response.json())
+
+    def invoke(self, tool_id: str, arguments: dict[str, Any]) -> Any:
+        query = str(arguments.get("query") or "").strip()
+        if not query.casefold().startswith(("select", "ask", "construct", "describe", "prefix", "base")):
+            raise CapabilityError("only read-only SPARQL queries are allowed")
+        if re.search(r"\b(insert|delete|load|clear|create|drop|copy|move|add|with)\b", query, re.IGNORECASE):
+            raise CapabilityError("SPARQL update operations are forbidden")
+        return self.request(
+            "POST", "", data={"query": query}, headers={"Accept": "application/sparql-results+json"}
+        ).json()
+
+
+class VoyantAdapter(HttpAdapter):
+    CONTRACT_VERSION = "2.x"
+
+    def __init__(self, endpoint: str, *, required: bool = False, enabled: bool = False, transport: Transport | None = None) -> None:
+        super().__init__(endpoint, transport=transport)
+        self.descriptor = CapabilityDescriptor(
+            "voyant",
+            "unibe-voyant",
+            "voyant-corpus-handoff",
+            self.CONTRACT_VERSION,
+            required,
+            enabled,
+            (ToolSpec("corpus.handoff", "Upload an approved text corpus", {"type": "object"}, {"type": "object"}, mutating=True),),
+        )
+
+    def discover(self) -> Availability:
+        response = self.request("GET", "")
+        return self.availability(self.descriptor, response, None)
+
+    def invoke(self, tool_id: str, arguments: dict[str, Any]) -> Any:
+        text = arguments.get("text")
+        if not isinstance(text, str) or not text.strip():
+            raise CapabilityError("Voyant hand-off requires non-empty approved text")
+        response = self.request("POST", "", data={"text": text})
+        return {"location": response.headers.get("Location"), "status_code": response.status_code}
+
+
+class RemoteToolAdapter(HttpAdapter):
+    CONTRACT_VERSION = "1.0"
+
+    def __init__(self, endpoint: str, *, enabled: bool = False, transport: Transport | None = None) -> None:
+        super().__init__(endpoint, transport=transport)
+        self._tools: tuple[ToolSpec, ...] = ()
+        self.descriptor = self._descriptor(enabled)
+
+    def _descriptor(self, enabled: bool) -> CapabilityDescriptor:
+        return CapabilityDescriptor(
+            "agent-tools",
+            "agentic-historian-tool-provider",
+            "provider-neutral-tools",
+            self.CONTRACT_VERSION,
+            False,
+            enabled,
+            self._tools,
+        )
+
+    def discover(self) -> Availability:
+        response = self.request("GET", "tools")
+        payload = response.json()
+        tools = []
+        for item in payload.get("tools", []):
+            tool_id = str(item.get("id") or item.get("name") or "")
+            if not tool_id:
+                continue
+            tools.append(
+                ToolSpec(
+                    tool_id,
+                    str(item.get("description") or ""),
+                    dict(item.get("input_schema") or item.get("parameters") or {}),
+                    dict(item.get("output_schema") or {}),
+                    bool(item.get("mutating")),
+                )
+            )
+        self._tools = tuple(tools)
+        self.descriptor = self._descriptor(self.descriptor.enabled)
+        return self.availability(self.descriptor, response, payload)
+
+    def invoke(self, tool_id: str, arguments: dict[str, Any]) -> Any:
+        return self.request("POST", "invoke", json={"tool": tool_id, "arguments": arguments}).json()
+
+
+def enabled(name: str, default: bool = False) -> bool:
+    return os.environ.get(name, str(default)).casefold() in {"1", "true", "yes", "on"}
+
+
+def default_registry(log_path: Path | None = None) -> Any:
+    """Build adapters strictly from environment values, with no secret output."""
+    try:
+        from scripts.atr_client import AtrClient
+    except ImportError:  # direct `python scripts/discover_capabilities.py`
+        from atr_client import AtrClient
+
+    from .provenance import JsonlInvocationLog
+    from .registry import CapabilityRegistry
+
+    registry = CapabilityRegistry(
+        invocation_log=JsonlInvocationLog(log_path) if log_path is not None else None
+    )
+    models = {
+        "text": os.environ.get("GPUSTACK_MODEL_TEXT") or os.environ.get("EXTRACTION_MODEL", ""),
+        "vision": os.environ.get("GPUSTACK_MODEL_VISION") or os.environ.get("QWEN3_VL_MODEL", ""),
+        "orchestrator": os.environ.get("GPUSTACK_MODEL_ORCHESTRATOR") or os.environ.get("ORCHESTRATOR_MODEL", ""),
+        "embedding": os.environ.get("GPUSTACK_MODEL_EMBEDDING", ""),
+        "reranker": os.environ.get("GPUSTACK_MODEL_RERANKER", ""),
+    }
+    registry.register(
+        GPUStackAdapter(
+            os.environ.get("GPUSTACK_BASE_URL", ""),
+            os.environ.get("GPUSTACK_API_KEY", ""),
+            models,
+            required=True,
+        )
+    )
+    atr_client = AtrClient(
+        os.environ.get("ATR_GATEWAY_URL", ""),
+        api_key=os.environ.get("ATR_API_KEY", ""),
+    )
+    registry.register(
+        ATRAdapter(
+            atr_client,
+            required=enabled("OUTREMER_CAPABILITY_ATR_REQUIRED"),
+            enabled=enabled("OUTREMER_CAPABILITY_ATR"),
+        )
+    )
+    registry.register(
+        MCPAdapter(
+            os.environ.get("MCP_BASE_URL", ""),
+            api_key=os.environ.get("MCP_API_KEY", ""),
+            enabled=enabled("OUTREMER_CAPABILITY_MCP"),
+        )
+    )
+    registry.register(QLeverAdapter(os.environ.get("QLEVER_ENDPOINT", ""), enabled=enabled("OUTREMER_CAPABILITY_QLEVER")))
+    registry.register(VoyantAdapter(os.environ.get("VOYANT_API_URL", ""), enabled=enabled("OUTREMER_CAPABILITY_VOYANT")))
+    registry.register(RemoteToolAdapter(os.environ.get("OUTREMER_TOOL_PROVIDER_URL", ""), enabled=enabled("OUTREMER_CAPABILITY_AGENT_TOOLS")))
+    return registry

--- a/scripts/capabilities/contracts.py
+++ b/scripts/capabilities/contracts.py
@@ -1,0 +1,107 @@
+"""Stable contracts shared by every infrastructure adapter."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal, Protocol
+
+CapabilityStatus = Literal["available", "unavailable", "disabled", "incompatible"]
+InvocationStatus = Literal["success", "error", "blocked"]
+
+
+class CapabilityError(RuntimeError):
+    """A capability is unavailable, incompatible, disabled, or failed."""
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    id: str
+    description: str
+    input_schema: dict[str, Any]
+    output_schema: dict[str, Any]
+    mutating: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class CapabilityDescriptor:
+    id: str
+    provider: str
+    contract: str
+    contract_version: str
+    required: bool
+    enabled: bool
+    tools: tuple[ToolSpec, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        result = asdict(self)
+        result["tools"] = [tool.to_dict() for tool in self.tools]
+        return result
+
+
+@dataclass(frozen=True)
+class Availability:
+    capability_id: str
+    status: CapabilityStatus
+    checked_at: str
+    provider_version: str | None = None
+    endpoint: str | None = None
+    tools: tuple[str, ...] = ()
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result = asdict(self)
+        result["tools"] = list(self.tools)
+        return result
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    """Reference plus digest; invocation logs never contain artifact payloads."""
+
+    uri: str
+    sha256: str
+    media_type: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.uri:
+            raise ValueError("artifact URI is required")
+        if not re.fullmatch(r"[0-9a-f]{64}", self.sha256):
+            raise ValueError("artifact sha256 must be 64 lowercase hexadecimal characters")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class InvocationRecord:
+    invocation_id: str
+    run_id: str
+    capability_id: str
+    tool_id: str
+    contract_version: str
+    provider_version: str | None
+    started_at: str
+    finished_at: str
+    latency_ms: int
+    status: InvocationStatus
+    inputs: list[ArtifactRef] = field(default_factory=list)
+    outputs: list[ArtifactRef] = field(default_factory=list)
+    error_type: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result = asdict(self)
+        result["inputs"] = [item.to_dict() for item in self.inputs]
+        result["outputs"] = [item.to_dict() for item in self.outputs]
+        return result
+
+
+class CapabilityAdapter(Protocol):
+    descriptor: CapabilityDescriptor
+
+    def discover(self) -> Availability: ...
+
+    def invoke(self, tool_id: str, arguments: dict[str, Any]) -> Any: ...

--- a/scripts/capabilities/provenance.py
+++ b/scripts/capabilities/provenance.py
@@ -1,0 +1,41 @@
+"""Append-only, payload-free capability invocation provenance."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .contracts import InvocationRecord
+
+SECRET_MARKERS = ("password", "secret", "token", "api_key", "authorization", "credential")
+
+
+def reject_secret_keys(value: Any, path: str = "record") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if any(marker in str(key).casefold() for marker in SECRET_MARKERS):
+                raise ValueError(f"secret-like key forbidden in provenance: {path}.{key}")
+            reject_secret_keys(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_secret_keys(child, f"{path}[{index}]")
+
+
+class JsonlInvocationLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def append(self, record: InvocationRecord) -> None:
+        value = record.to_dict()
+        reject_secret_keys(value)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(value, ensure_ascii=False, sort_keys=True) + "\n"
+        flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+        fd = os.open(self.path, flags, 0o640)
+        try:
+            os.write(fd, line.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)

--- a/scripts/capabilities/registry.py
+++ b/scripts/capabilities/registry.py
@@ -1,0 +1,139 @@
+"""Required/optional capability policy, discovery, invocation, and audit."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from .contracts import (
+    ArtifactRef,
+    Availability,
+    CapabilityAdapter,
+    CapabilityError,
+    InvocationRecord,
+)
+from .provenance import JsonlInvocationLog
+
+
+def timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class CapabilityRegistry:
+    def __init__(
+        self,
+        *,
+        invocation_log: JsonlInvocationLog | None = None,
+        audit_required: bool = True,
+    ) -> None:
+        self._adapters: dict[str, CapabilityAdapter] = {}
+        self._availability: dict[str, Availability] = {}
+        self.invocation_log = invocation_log
+        self.audit_required = audit_required
+
+    def register(self, adapter: CapabilityAdapter) -> None:
+        cap_id = adapter.descriptor.id
+        if cap_id in self._adapters:
+            raise ValueError(f"duplicate capability id: {cap_id}")
+        self._adapters[cap_id] = adapter
+
+    def descriptors(self) -> list[dict[str, Any]]:
+        return [self._adapters[key].descriptor.to_dict() for key in sorted(self._adapters)]
+
+    def discover(self) -> dict[str, Any]:
+        errors: list[str] = []
+        results: list[Availability] = []
+        for cap_id in sorted(self._adapters):
+            adapter = self._adapters[cap_id]
+            if not adapter.descriptor.enabled:
+                availability = Availability(cap_id, "disabled", timestamp())
+            else:
+                try:
+                    availability = adapter.discover()
+                except Exception as exc:  # provider failures become explicit state
+                    availability = Availability(
+                        cap_id,
+                        "unavailable",
+                        timestamp(),
+                        detail=f"{type(exc).__name__}: {exc}",
+                    )
+            self._availability[cap_id] = availability
+            results.append(availability)
+            if adapter.descriptor.required and availability.status != "available":
+                errors.append(f"required capability {cap_id}: {availability.status}")
+        return {
+            "schema_version": 1,
+            "checked_at": timestamp(),
+            "status": "pass" if not errors else "fail",
+            "capabilities": [item.to_dict() for item in results],
+            "errors": errors,
+        }
+
+    def require_ready(self) -> None:
+        report = self.discover()
+        if report["status"] != "pass":
+            raise CapabilityError("; ".join(report["errors"]))
+
+    def invoke(
+        self,
+        capability_id: str,
+        tool_id: str,
+        arguments: dict[str, Any],
+        *,
+        run_id: str,
+        inputs: list[ArtifactRef] | None = None,
+        output_refs: list[ArtifactRef] | None = None,
+    ) -> Any:
+        adapter = self._adapters.get(capability_id)
+        if adapter is None:
+            raise CapabilityError(f"unknown capability: {capability_id}")
+        if self.audit_required and self.invocation_log is None:
+            raise CapabilityError("capability invocation requires an append-only audit log")
+        descriptor = adapter.descriptor
+        availability = self._availability.get(capability_id)
+        if availability is None:
+            availability = adapter.discover() if descriptor.enabled else Availability(
+                capability_id, "disabled", timestamp()
+            )
+            self._availability[capability_id] = availability
+            descriptor = adapter.descriptor  # discovery may populate dynamic tools
+        known_tools = {tool.id for tool in descriptor.tools}
+        if tool_id not in known_tools:
+            raise CapabilityError(f"{capability_id}: unknown tool {tool_id}")
+        started_at = timestamp()
+        start = time.monotonic()
+        status = "success"
+        error_type = None
+        try:
+            if availability.status != "available":
+                status = "blocked"
+                raise CapabilityError(
+                    f"{capability_id} is {availability.status}: {availability.detail or ''}".strip()
+                )
+            return adapter.invoke(tool_id, arguments)
+        except Exception as exc:
+            if status != "blocked":
+                status = "error"
+            error_type = type(exc).__name__
+            raise
+        finally:
+            if self.invocation_log:
+                self.invocation_log.append(
+                    InvocationRecord(
+                        invocation_id=str(uuid.uuid4()),
+                        run_id=run_id,
+                        capability_id=capability_id,
+                        tool_id=tool_id,
+                        contract_version=descriptor.contract_version,
+                        provider_version=availability.provider_version,
+                        started_at=started_at,
+                        finished_at=timestamp(),
+                        latency_ms=round((time.monotonic() - start) * 1000),
+                        status=status,  # type: ignore[arg-type]
+                        inputs=inputs or [],
+                        outputs=output_refs or [],
+                        error_type=error_type,
+                    )
+                )

--- a/scripts/capability_smoke.py
+++ b/scripts/capability_smoke.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Run safe discovery probes against the configured shared capability stack."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from capabilities.adapters import default_registry
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--require",
+        default="gpustack,atr,mcp,qlever,voyant",
+        help="comma-separated capability ids that must report available",
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    report = default_registry().discover()
+    by_id = {item["capability_id"]: item for item in report["capabilities"]}
+    required = {item.strip() for item in args.require.split(",") if item.strip()}
+    errors = [
+        f"{cap_id}: {by_id.get(cap_id, {}).get('status', 'missing')}"
+        for cap_id in sorted(required)
+        if by_id.get(cap_id, {}).get("status") != "available"
+    ]
+    result = {**report, "smoke_required": sorted(required), "smoke_errors": errors}
+    result["status"] = "pass" if not errors else "fail"
+    content = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(content, encoding="utf-8")
+    else:
+        print(content, end="")
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/discover_capabilities.py
+++ b/scripts/discover_capabilities.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Discover configured shared capabilities and emit a secret-free report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from capabilities.adapters import default_registry
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--invocation-log", type=Path)
+    parser.add_argument("--require-ready", action="store_true")
+    args = parser.parse_args()
+    registry = default_registry(args.invocation_log)
+    report = registry.discover()
+    content = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(content, encoding="utf-8")
+    else:
+        print(content, end="")
+    return 1 if args.require_ready and report["status"] != "pass" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_capability_adapters.py
+++ b/tests/test_capability_adapters.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from scripts.capabilities.adapters import (
+    ATRAdapter,
+    GPUStackAdapter,
+    MCPAdapter,
+    QLeverAdapter,
+    RemoteToolAdapter,
+    VoyantAdapter,
+    default_registry,
+)
+from scripts.capabilities.contracts import (
+    ArtifactRef,
+    Availability,
+    CapabilityDescriptor,
+    CapabilityError,
+    ToolSpec,
+)
+from scripts.capabilities.provenance import JsonlInvocationLog
+from scripts.capabilities.registry import CapabilityRegistry
+
+ROOT = Path(__file__).parents[1]
+
+
+def response(status: int = 200, payload=None, *, headers=None) -> httpx.Response:
+    request = httpx.Request("GET", "https://provider.test")
+    return httpx.Response(status, json=payload, headers=headers, request=request)
+
+
+class FakeAdapter:
+    def __init__(self, cap_id: str, *, required=False, enabled=True, status="available"):
+        self.descriptor = CapabilityDescriptor(
+            cap_id,
+            "fake",
+            "fake-contract",
+            "1",
+            required,
+            enabled,
+            (ToolSpec("fake.run", "run", {}, {}),),
+        )
+        self.status = status
+
+    def discover(self):
+        return Availability(self.descriptor.id, self.status, "now", provider_version="v1")
+
+    def invoke(self, tool_id, arguments):
+        if arguments.get("fail"):
+            raise RuntimeError("provider failed")
+        return {"ok": True}
+
+
+def test_registry_blocks_missing_required_but_surfaces_optional() -> None:
+    registry = CapabilityRegistry()
+    registry.register(FakeAdapter("required", required=True, status="unavailable"))
+    registry.register(FakeAdapter("optional", status="unavailable"))
+    registry.register(FakeAdapter("disabled", enabled=False))
+    report = registry.discover()
+    assert report["status"] == "fail"
+    assert report["errors"] == ["required capability required: unavailable"]
+    assert {item["capability_id"]: item["status"] for item in report["capabilities"]} == {
+        "disabled": "disabled",
+        "optional": "unavailable",
+        "required": "unavailable",
+    }
+
+
+def test_invocation_log_records_refs_not_arguments_or_payload(tmp_path: Path) -> None:
+    log_path = tmp_path / "invocations.jsonl"
+    registry = CapabilityRegistry(invocation_log=JsonlInvocationLog(log_path))
+    registry.register(FakeAdapter("cap"))
+    registry.discover()
+    result = registry.invoke(
+        "cap",
+        "fake.run",
+        {"source_text": "PRIVATE", "api_key": "NEVER-LOG"},
+        run_id="run-1",
+        inputs=[ArtifactRef("urn:input", "a" * 64)],
+        output_refs=[ArtifactRef("urn:output", "b" * 64)],
+    )
+    assert result == {"ok": True}
+    raw = log_path.read_text()
+    assert "PRIVATE" not in raw and "NEVER-LOG" not in raw
+    record = json.loads(raw)
+    assert record["status"] == "success"
+    assert record["inputs"][0]["sha256"] == "a" * 64
+
+
+def test_failed_and_blocked_invocations_are_audited(tmp_path: Path) -> None:
+    log_path = tmp_path / "invocations.jsonl"
+    registry = CapabilityRegistry(invocation_log=JsonlInvocationLog(log_path))
+    registry.register(FakeAdapter("failure"))
+    registry.register(FakeAdapter("blocked", enabled=False))
+    registry.discover()
+    with pytest.raises(RuntimeError):
+        registry.invoke("failure", "fake.run", {"fail": True}, run_id="run")
+    with pytest.raises(CapabilityError):
+        registry.invoke("blocked", "fake.run", {}, run_id="run")
+    records = [json.loads(line) for line in log_path.read_text().splitlines()]
+    assert [item["status"] for item in records] == ["error", "blocked"]
+    assert records[0]["error_type"] == "RuntimeError"
+
+
+def test_gpustack_discovers_roles_and_routes_tools() -> None:
+    seen = []
+
+    def transport(method, url, **kwargs):
+        seen.append((method, url, kwargs.get("json")))
+        if method == "GET":
+            return response(payload={"data": [{"id": name} for name in ("text", "vision", "orch", "embed", "rank")]})
+        return response(payload={"ok": True})
+
+    adapter = GPUStackAdapter(
+        "https://gpu.test/v1",
+        "credential",
+        {"text": "text", "vision": "vision", "orchestrator": "orch", "embedding": "embed", "reranker": "rank"},
+        transport=transport,
+    )
+    assert adapter.discover().status == "available"
+    adapter.invoke("embedding.embed", {"input": ["a"]})
+    adapter.invoke("reranker.rerank", {"query": "q", "documents": ["a"]})
+    adapter.invoke("text.generate", {"messages": []})
+    assert [item[1].rsplit("/", 1)[-1] for item in seen] == ["models", "embeddings", "rerank", "completions"]
+    assert seen[-1][2]["model"] == "text"
+
+
+def test_gpustack_reports_missing_configured_model() -> None:
+    adapter = GPUStackAdapter(
+        "https://gpu.test/v1",
+        "credential",
+        {"text": "text", "vision": "vision", "orchestrator": "orch"},
+        transport=lambda *args, **kwargs: response(payload={"data": [{"id": "text"}]}),
+    )
+    result = adapter.discover()
+    assert result.status == "incompatible"
+    assert "orch" in result.detail
+
+
+class FakeAtrClient:
+    base_url = "http://atr.test"
+
+    def health_check(self):
+        return {"version": "1.2"}
+
+    def list_models(self):
+        return [{"id": "kraken"}]
+
+    def segment(self, image, seg_mode="baseline"):
+        return {"lines": [], "mode": seg_mode}
+
+    def transcribe(self, image, model, engine="kraken", seg_mode="baseline"):
+        return SimpleNamespace(
+            text="text", confidence=0.9, model=model, engine=engine, service_version="1.2"
+        )
+
+
+def test_atr_shim_preserves_attributed_result() -> None:
+    adapter = ATRAdapter(FakeAtrClient(), enabled=True)
+    assert adapter.discover().provider_version == "1.2"
+    result = adapter.invoke("atr.ocr", {"image": b"image", "model": "kraken"})
+    assert result == {
+        "text": "text",
+        "confidence": 0.9,
+        "model": "kraken",
+        "engine": "kraken",
+        "service_version": "1.2",
+    }
+    recognized = adapter.invoke("atr.recognize", {"image": b"image", "model": "party-model"})
+    assert recognized["engine"] == "party"
+
+
+def test_mcp_initializes_discovers_and_maps_candidates_without_merging() -> None:
+    calls = []
+
+    def transport(method, url, **kwargs):
+        payload = kwargs["json"]
+        calls.append(payload["method"])
+        if payload["method"] == "initialize":
+            return response(payload={"jsonrpc": "2.0", "id": 1, "result": {}}, headers={"Mcp-Session-Id": "s"})
+        if payload["method"] == "tools/list":
+            return response(payload={"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": "search_persons"}]}})
+        return response(status=202, payload={})
+
+    adapter = MCPAdapter("https://mcp.test/mcp", enabled=True, transport=transport)
+    availability = adapter.discover()
+    assert availability.tools == ("search_persons",)
+    assert calls == ["initialize", "notifications/initialized", "tools/list"]
+    candidates = adapter.to_outremer_candidates(
+        {"persons": [{"source": "hls", "pid": "42", "name": "Anna", "wikidata_id": "Q1"}]}
+    )
+    assert candidates == [
+        {
+            "candidate_id": "mcp:hls:42",
+            "label": "Anna",
+            "source": "hls",
+            "source_id": "42",
+            "variants": [],
+            "external_ids": {"wikidata_id": "Q1"},
+            "status": "unreviewed",
+        }
+    ]
+
+
+def test_qlever_is_read_only_even_after_prefix() -> None:
+    adapter = QLeverAdapter(
+        "https://qlever.test/query",
+        enabled=True,
+        transport=lambda *args, **kwargs: response(payload={"boolean": True}),
+    )
+    assert adapter.discover().status == "available"
+    assert adapter.invoke("graph.query", {"query": "ASK { ?s ?p ?o }"}) == {"boolean": True}
+    with pytest.raises(CapabilityError, match="update"):
+        adapter.invoke("graph.query", {"query": "PREFIX x: <urn:x> DELETE WHERE { ?s ?p ?o }"})
+
+
+def test_voyant_requires_explicit_nonempty_text() -> None:
+    seen = []
+
+    def transport(method, url, **kwargs):
+        seen.append((method, kwargs.get("data")))
+        return response(payload={}, headers={"Location": "https://voyant.test/?corpus=1"})
+
+    adapter = VoyantAdapter("https://voyant.test", enabled=True, transport=transport)
+    assert adapter.discover().status == "available"
+    with pytest.raises(CapabilityError):
+        adapter.invoke("corpus.handoff", {"text": " "})
+    result = adapter.invoke("corpus.handoff", {"text": "approved corpus"})
+    assert result["location"].endswith("corpus=1")
+    assert seen[-1] == ("POST", {"text": "approved corpus"})
+
+
+def test_remote_tools_are_discovered_not_hardcoded() -> None:
+    def transport(method, url, **kwargs):
+        if method == "GET":
+            return response(
+                payload={
+                    "version": "2",
+                    "tools": [
+                        {
+                            "id": "source.describe",
+                            "description": "describe",
+                            "input_schema": {"type": "object"},
+                            "output_schema": {"type": "object"},
+                        }
+                    ],
+                }
+            )
+        return response(payload={"artifact": "urn:result"})
+
+    adapter = RemoteToolAdapter("https://tools.test", enabled=True, transport=transport)
+    assert adapter.discover().tools == ("source.describe",)
+    assert adapter.invoke("source.describe", {"artifact": "urn:source"}) == {"artifact": "urn:result"}
+
+    registry = CapabilityRegistry(audit_required=False)
+    registry.register(RemoteToolAdapter("https://tools.test", enabled=True, transport=transport))
+    assert registry.invoke(
+        "agent-tools", "source.describe", {"artifact": "urn:source"}, run_id="run"
+    ) == {"artifact": "urn:result"}
+
+
+def test_registry_refuses_unaudited_invocation() -> None:
+    registry = CapabilityRegistry()
+    registry.register(FakeAdapter("cap"))
+    with pytest.raises(CapabilityError, match="audit log"):
+        registry.invoke("cap", "fake.run", {}, run_id="run")
+
+
+def test_artifact_refs_require_real_digests() -> None:
+    with pytest.raises(ValueError, match="sha256"):
+        ArtifactRef("urn:artifact", "not-a-digest")
+
+
+def test_adapter_package_does_not_import_agentic_historian_internals() -> None:
+    imports = []
+    for path in (ROOT / "scripts/capabilities").glob("*.py"):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.append(node.module)
+    assert not any(name == "agentic_historian" or name.startswith("agentic_historian.") for name in imports)
+
+
+@pytest.mark.live_backend
+@pytest.mark.skipif(
+    os.environ.get("OUTREMER_LIVE_CAPABILITY_SMOKE") != "1",
+    reason="set on the protected university runner only",
+)
+def test_live_shared_capability_discovery() -> None:
+    report = default_registry().discover()
+    by_id = {item["capability_id"]: item["status"] for item in report["capabilities"]}
+    assert all(by_id.get(capability) == "available" for capability in ("gpustack", "atr", "mcp", "qlever", "voyant"))


### PR DESCRIPTION
## What changed

- add provider-neutral capability/tool descriptors, availability states, required/optional policy, and a registry
- add adapters for role-routed GPUStack generation/embeddings/reranking, ATR, MCP federation, read-only QLever SPARQL, Voyant hand-off, and remotely discovered agent tools
- add MCP-to-Outremer anti-corruption mapping that preserves source-local identity and emits unreviewed candidates rather than authority truth
- add startup discovery and safe live-smoke commands
- add append-only invocation provenance with artifact references, versions, latency and status; arguments/responses are never logged and unaudited invocation fails closed
- add feature flags and full architecture/live-staging documentation
- add 13 passing offline contract tests plus one protected live-backend test

## Boundaries

- no `agentic_historian` application, Discord, deployment-state, or repository-internal import
- direct-name GPUStack variables remain compatibility fallbacks until #88 merges
- ATR is explicitly a temporary shim around Outremer's existing client; #87/#90 must replace it with the selected shared package/service contract
- adapters cannot mutate Outremer evidence or authority records directly
- QLever rejects SPARQL updates; Voyant hand-off is explicitly marked mutating and requires approved non-empty text
- branch is directly from `origin/main`, not stacked on #117–#119

## Verification

- `pytest -q tests/test_capability_adapters.py` — 13 passed, 1 live-only skipped
- `ruff check scripts/capabilities scripts/discover_capabilities.py scripts/capability_smoke.py tests/test_capability_adapters.py`
- module compile/AST checks and no-agentic-internal-import test
- `git diff --check`
- full suite on host Python 3.10: 193 passed, 2 skipped, with the same unrelated exact-float failure documented on #118; GitHub CI runs supported Python 3.12

## Remaining acceptance

This PR intentionally does **not** close #113. Completion still requires the #90 sharing decision, #87 shared ATR-client migration/removal of the temporary shim, and a protected staging smoke run covering GPUStack, ATR, one MCP source, QLever, and Voyant.

Part of #113
